### PR TITLE
Clean up LLDP subtype and class strings

### DIFF
--- a/layers/lldp.go
+++ b/layers/lldp.go
@@ -1449,7 +1449,7 @@ func (t LLDPPowerPriority) String() (s string) {
 func (t LLDPMediaSubtype) String() (s string) {
 	switch t {
 	case LLDPMediaTypeCapabilities:
-		s = "Media Capabilities "
+		s = "Media Capabilities"
 	case LLDPMediaTypeNetwork:
 		s = "Network Policy"
 	case LLDPMediaTypeLocation:
@@ -1487,7 +1487,7 @@ func (t LLDPMediaClass) String() (s string) {
 	case LLDPMediaClassEndpointIII:
 		s = "Endpoint Class III"
 	case LLDPMediaClassNetwork:
-		s = "Network connectivity "
+		s = "Network Connectivity"
 	default:
 		s = "Unknown"
 	}


### PR DESCRIPTION
Trailing whitespace in two LLDP strings has been removed. I searched across the `layers` package and didn't see any other strings like this.