### PR TITLE
feat(pcapgo): support cancellation with context.Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ examples/reassemblydump/reassemblydump
 layers/gen
 macs/gen
 pcap/pcap_tester
+.idea/

--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -190,24 +190,9 @@ func (ip *IPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		df.SetTruncated()
 		return fmt.Errorf("Invalid ip4 header. Length %d less than 20", len(data))
 	}
-	flagsfrags := binary.BigEndian.Uint16(data[6:8])
 
-	ip.Version = uint8(data[0]) >> 4
-	ip.IHL = uint8(data[0]) & 0x0F
-	ip.TOS = data[1]
 	ip.Length = binary.BigEndian.Uint16(data[2:4])
-	ip.Id = binary.BigEndian.Uint16(data[4:6])
-	ip.Flags = IPv4Flag(flagsfrags >> 13)
-	ip.FragOffset = flagsfrags & 0x1FFF
-	ip.TTL = data[8]
-	ip.Protocol = IPProtocol(data[9])
-	ip.Checksum = binary.BigEndian.Uint16(data[10:12])
-	ip.SrcIP = data[12:16]
-	ip.DstIP = data[16:20]
-	ip.Options = ip.Options[:0]
-	ip.Padding = nil
-	// Set up an initial guess for contents/payload... we'll reset these soon.
-	ip.BaseLayer = BaseLayer{Contents: data}
+	ip.IHL = uint8(data[0]) & 0x0F
 
 	// This code is added for the following enviroment:
 	// * Windows 10 with TSO option activated. ( tested on Hyper-V, RealTek ethernet driver )
@@ -224,6 +209,7 @@ func (ip *IPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	} else if int(ip.IHL*4) > int(ip.Length) {
 		return fmt.Errorf("Invalid IP header length > IP length (%d > %d)", ip.IHL, ip.Length)
 	}
+
 	if cmp := len(data) - int(ip.Length); cmp > 0 {
 		data = data[:ip.Length]
 	} else if cmp < 0 {
@@ -232,45 +218,65 @@ func (ip *IPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 			return errors.New("Not all IP header bytes available")
 		}
 	}
+
+	ip.Options = ip.Options[:0]
 	ip.Contents = data[:ip.IHL*4]
 	ip.Payload = data[ip.IHL*4:]
+
 	// From here on, data contains the header options.
-	data = data[20 : ip.IHL*4]
+	headerOptionsData := data[20 : ip.IHL*4]
 	// Pull out IP options
-	for len(data) > 0 {
+	for len(headerOptionsData) > 0 {
 		if ip.Options == nil {
 			// Pre-allocate to avoid growing the slice too much.
 			ip.Options = make([]IPv4Option, 0, 4)
 		}
-		opt := IPv4Option{OptionType: data[0]}
+
+		opt := IPv4Option{OptionType: headerOptionsData[0]}
 		switch opt.OptionType {
 		case 0: // End of options
 			opt.OptionLength = 1
 			ip.Options = append(ip.Options, opt)
-			ip.Padding = data[1:]
+			ip.Padding = headerOptionsData[1:]
+
 			return nil
 		case 1: // 1 byte padding
 			opt.OptionLength = 1
-			data = data[1:]
+			headerOptionsData = headerOptionsData[1:]
 			ip.Options = append(ip.Options, opt)
 		default:
-			if len(data) < 2 {
+			if len(headerOptionsData) < 2 {
 				df.SetTruncated()
-				return fmt.Errorf("Invalid ip4 option length. Length %d less than 2", len(data))
+				return fmt.Errorf("Invalid ip4 option length. Length %d less than 2", len(headerOptionsData))
 			}
-			opt.OptionLength = data[1]
-			if len(data) < int(opt.OptionLength) {
+
+			opt.OptionLength = headerOptionsData[1]
+			if len(headerOptionsData) < int(opt.OptionLength) {
 				df.SetTruncated()
 				return fmt.Errorf("IP option length exceeds remaining IP header size, option type %v length %v", opt.OptionType, opt.OptionLength)
 			}
 			if opt.OptionLength <= 2 {
 				return fmt.Errorf("Invalid IP option type %v length %d. Must be greater than 2", opt.OptionType, opt.OptionLength)
 			}
-			opt.OptionData = data[2:opt.OptionLength]
-			data = data[opt.OptionLength:]
+			opt.OptionData = headerOptionsData[2:opt.OptionLength]
+			headerOptionsData = headerOptionsData[opt.OptionLength:]
 			ip.Options = append(ip.Options, opt)
 		}
 	}
+
+	flagsfrags := binary.BigEndian.Uint16(data[6:8])
+	ip.Version = data[0] >> 4
+	ip.TOS = data[1]
+	ip.Id = binary.BigEndian.Uint16(data[4:6])
+	ip.Flags = IPv4Flag(flagsfrags >> 13)
+	ip.FragOffset = flagsfrags & 0x1FFF
+	ip.TTL = data[8]
+	ip.Protocol = IPProtocol(data[9])
+	ip.Checksum = binary.BigEndian.Uint16(data[10:12])
+	ip.SrcIP = data[12:16]
+	ip.DstIP = data[16:20]
+	ip.Padding = nil
+
 	return nil
 }
 

--- a/packet.go
+++ b/packet.go
@@ -8,6 +8,7 @@ package gopacket
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -17,8 +18,21 @@ import (
 	"reflect"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
+)
+
+const maximumMTU = 1500
+
+var (
+	ErrNoLayersAdded = errors.New("NextDecoder called, but no layers added yet")
+	poolPackedPool   = &sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, maximumMTU)
+			return &b
+		},
+	}
 )
 
 // CaptureInfo provides standardized information about a packet captured off
@@ -97,6 +111,11 @@ type Packet interface {
 	Data() []byte
 	// Metadata returns packet metadata associated with this packet.
 	Metadata() *PacketMetadata
+}
+
+type PooledPacket interface {
+	Packet
+	Dispose()
 }
 
 // packet contains all the information we need to fulfill the Packet interface,
@@ -199,6 +218,15 @@ func (p *packet) recoverDecodeError() {
 			p.addFinalDecodeError(fmt.Errorf("%v", r), debug.Stack())
 		}
 	}
+}
+
+type pooledPacket struct {
+	Packet
+	origData *[]byte
+}
+
+func (p pooledPacket) Dispose() {
+	poolPackedPool.Put(p.origData)
 }
 
 // LayerString outputs an individual layer as a string.  The layer is output
@@ -441,7 +469,7 @@ func (p *eagerPacket) NextDecoder(next Decoder) error {
 		return errNilDecoder
 	}
 	if p.last == nil {
-		return errors.New("NextDecoder called, but no layers added yet")
+		return ErrNoLayersAdded
 	}
 	d := p.last.LayerPayload()
 	if len(d) == 0 {
@@ -619,6 +647,11 @@ type DecodeOptions struct {
 	// there's any chance that those bytes WILL be changed, this will invalidate
 	// your packets.
 	NoCopy bool
+	// Pool decoding only applies if NoCopy is false.
+	// Instead of always allocating new memory it takes the memory from a pool.
+	// NewPacket then will return a PooledPacket instead of a Packet.
+	// As soon as you're done with the PooledPacket you should call PooledPacket.Dispose() to return it to the pool.
+	Pool bool
 	// SkipDecodeRecovery skips over panic recovery during packet decoding.
 	// Normally, when packets decode, if a panic occurs, that panic is captured
 	// by a recover(), and a DecodeFailure layer is added to the packet detailing
@@ -653,18 +686,32 @@ var DecodeStreamsAsDatagrams = DecodeOptions{DecodeStreamsAsDatagrams: true}
 // NewPacket creates a new Packet object from a set of bytes.  The
 // firstLayerDecoder tells it how to interpret the first layer from the bytes,
 // future layers will be generated from that first layer automatically.
-func NewPacket(data []byte, firstLayerDecoder Decoder, options DecodeOptions) Packet {
+func NewPacket(data []byte, firstLayerDecoder Decoder, options DecodeOptions) (p Packet) {
 	if !options.NoCopy {
-		dataCopy := make([]byte, len(data))
-		copy(dataCopy, data)
-		data = dataCopy
+		var (
+			poolMemory *[]byte
+			dataCopy   []byte
+		)
+		if options.Pool && len(data) <= maximumMTU {
+			poolMemory = poolPackedPool.Get().(*[]byte)
+			dataCopy = (*poolMemory)[:len(data)]
+			copy(dataCopy, data)
+			data = dataCopy
+			defer func() {
+				p = &pooledPacket{Packet: p, origData: poolMemory}
+			}()
+		} else {
+			dataCopy = make([]byte, len(data))
+			copy(dataCopy, data)
+			data = dataCopy
+		}
 	}
 	if options.Lazy {
-		p := &lazyPacket{
+		lp := &lazyPacket{
 			packet: packet{data: data, decodeOptions: options},
 			next:   firstLayerDecoder,
 		}
-		p.layers = p.initialLayers[:0]
+		lp.layers = lp.initialLayers[:0]
 		// Crazy craziness:
 		// If the following return statemet is REMOVED, and Lazy is FALSE, then
 		// eager packet processing becomes 17% FASTER.  No, there is no logical
@@ -675,14 +722,14 @@ func NewPacket(data []byte, firstLayerDecoder Decoder, options DecodeOptions) Pa
 		// runtime.morestack/runtime.lessstack.  We'll hope the compiler gets better
 		// over time and we get this optimization for free.  Until then, we'll have
 		// to live with slower packet processing.
-		return p
+		return lp
 	}
-	p := &eagerPacket{
+	ep := &eagerPacket{
 		packet: packet{data: data, decodeOptions: options},
 	}
-	p.layers = p.initialLayers[:0]
-	p.initialDecode(firstLayerDecoder)
-	return p
+	ep.layers = ep.initialLayers[:0]
+	ep.initialDecode(firstLayerDecoder)
+	return ep
 }
 
 // PacketDataSource is an interface for some source of packet data.  Users may
@@ -716,7 +763,7 @@ type concat []PacketDataSource
 func (c *concat) ReadPacketData() (data []byte, ci CaptureInfo, err error) {
 	for len(*c) > 0 {
 		data, ci, err = (*c)[0].ReadPacketData()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			*c = (*c)[1:]
 			continue
 		}
@@ -742,6 +789,46 @@ type ZeroCopyPacketDataSource interface {
 	//  err:  An error encountered while reading packet data.  If err != nil,
 	//    then data/ci will be ignored.
 	ZeroCopyReadPacketData() (data []byte, ci CaptureInfo, err error)
+}
+
+type PacketSourceOption interface {
+	apply(ps *PacketSource)
+}
+
+type packetSourceOptionFunc func(ps *PacketSource)
+
+func (f packetSourceOptionFunc) apply(ps *PacketSource) {
+	f(ps)
+}
+
+func WithLazy(lazy bool) packetSourceOptionFunc {
+	return func(ps *PacketSource) {
+		ps.Lazy = lazy
+	}
+}
+
+func WithNoCopy(noCopy bool) packetSourceOptionFunc {
+	return func(ps *PacketSource) {
+		ps.NoCopy = noCopy
+	}
+}
+
+func WithPool(pool bool) packetSourceOptionFunc {
+	return func(ps *PacketSource) {
+		ps.Pool = pool
+	}
+}
+
+func WithSkipDecodeRecovery(skipDecodeRecovery bool) packetSourceOptionFunc {
+	return func(ps *PacketSource) {
+		ps.SkipDecodeRecovery = skipDecodeRecovery
+	}
+}
+
+func WithDecodeStreamsAsDatagrams(decodeStreamsAsDatagrams bool) packetSourceOptionFunc {
+	return func(ps *PacketSource) {
+		ps.DecodeStreamsAsDatagrams = decodeStreamsAsDatagrams
+	}
 }
 
 // PacketSource reads in packets from a PacketDataSource, decodes them, and
@@ -782,8 +869,9 @@ type ZeroCopyPacketDataSource interface {
 //	  handlePacket(packet)  // Do something with each packet.
 //	}
 type PacketSource struct {
-	source  PacketDataSource
-	decoder Decoder
+	zeroCopy bool
+	source   func() (data []byte, ci CaptureInfo, err error)
+	decoder  Decoder
 	// DecodeOptions is the set of options to use for decoding each piece
 	// of packet data.  This can/should be changed by the user to reflect the
 	// way packets should be decoded.
@@ -791,18 +879,38 @@ type PacketSource struct {
 	c chan Packet
 }
 
-// NewPacketSource creates a packet data source.
-func NewPacketSource(source PacketDataSource, decoder Decoder) *PacketSource {
-	return &PacketSource{
-		source:  source,
+// NewZeroCopyPacketSource creates a zero copy packet data source.
+func NewZeroCopyPacketSource(source ZeroCopyPacketDataSource, decoder Decoder, opts ...PacketSourceOption) *PacketSource {
+	ps := &PacketSource{
+		source:  source.ZeroCopyReadPacketData,
 		decoder: decoder,
 	}
+
+	for idx := range opts {
+		opts[idx].apply(ps)
+	}
+
+	return ps
+}
+
+// NewPacketSource creates a packet data source.
+func NewPacketSource(source PacketDataSource, decoder Decoder, opts ...PacketSourceOption) *PacketSource {
+	ps := &PacketSource{
+		source:  source.ReadPacketData,
+		decoder: decoder,
+	}
+
+	for idx := range opts {
+		opts[idx].apply(ps)
+	}
+
+	return ps
 }
 
 // NextPacket returns the next decoded packet from the PacketSource.  On error,
 // it returns a nil packet and a non-nil error.
 func (p *PacketSource) NextPacket() (Packet, error) {
-	data, ci, err := p.source.ReadPacketData()
+	data, ci, err := p.source()
 	if err != nil {
 		return nil, err
 	}
@@ -816,9 +924,9 @@ func (p *PacketSource) NextPacket() (Packet, error) {
 // packetsToChannel reads in all packets from the packet source and sends them
 // to the given channel. This routine terminates when a non-temporary error
 // is returned by NextPacket().
-func (p *PacketSource) packetsToChannel() {
+func (p *PacketSource) packetsToChannel(ctx context.Context) {
 	defer close(p.c)
-	for {
+	for ctx.Err() == nil {
 		packet, err := p.NextPacket()
 		if err == nil {
 			p.c <- packet
@@ -826,19 +934,16 @@ func (p *PacketSource) packetsToChannel() {
 		}
 
 		// Immediately retry for temporary network errors
-		if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-			continue
-		}
-
-		// Immediately retry for EAGAIN
-		if err == syscall.EAGAIN {
+		var netErr net.Error
+		if ok := errors.As(err, &netErr); ok && netErr.Timeout() {
+			time.Sleep(time.Millisecond * time.Duration(5))
 			continue
 		}
 
 		// Immediately break for known unrecoverable errors
-		if err == io.EOF || err == io.ErrUnexpectedEOF ||
-			err == io.ErrNoProgress || err == io.ErrClosedPipe || err == io.ErrShortBuffer ||
-			err == syscall.EBADF ||
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+			errors.Is(err, io.ErrNoProgress) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, io.ErrShortBuffer) ||
+			errors.Is(err, syscall.EBADF) ||
 			strings.Contains(err.Error(), "use of closed file") {
 			break
 		}
@@ -855,14 +960,36 @@ func (p *PacketSource) packetsToChannel() {
 // If any other error is encountered, it is ignored.
 //
 //	for packet := range packetSource.Packets() {
-//	  handlePacket(packet)  // Do something with each packet.
+//	  handlePacket(packet)  // Do something with each packet
 //	}
 //
 // If called more than once, returns the same channel.
 func (p *PacketSource) Packets() chan Packet {
+	return p.PacketsCtx(context.Background())
+}
+
+// PacketsCtx returns a channel of packets, allowing easy iterating over
+// packets.  Packets will be asynchronously read in from the underlying
+// PacketDataSource and written to the returned channel.  If the underlying
+// PacketDataSource returns an io.EOF error, the channel will be closed.
+// If any other error is encountered, it is ignored.
+// The background Go routine will be canceled as soon as the given context
+// returns an error either because it got canceled or it has reached its deadline.
+//
+//	for packet := range packetSource.PacketsCtx(context.Background()) {
+//	  handlePacket(packet)  // Do something with each packet.
+//	}
+//
+// If called more than once, returns the same channel.
+func (p *PacketSource) PacketsCtx(ctx context.Context) chan Packet {
+	if p.DecodeOptions.NoCopy && p.zeroCopy {
+		panic("PacketSource uses a zero copy datasource and NoCopy decoder option activated - Packets() uses a buffered channel hence packets are most likely overwritten")
+	}
+
+	const defaultPacketChannelSize = 1000
 	if p.c == nil {
-		p.c = make(chan Packet, 1000)
-		go p.packetsToChannel()
+		p.c = make(chan Packet, defaultPacketChannelSize)
+		go p.packetsToChannel(ctx)
 	}
 	return p.c
 }

--- a/pcapgo/capture.go
+++ b/pcapgo/capture.go
@@ -3,16 +3,17 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file in the root of the source
 // tree.
-//go:build linux && go1.9
-// +build linux,go1.9
+//go:build linux
 
 package pcapgo
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -32,7 +33,7 @@ func htons(data uint16) uint16 { return data<<8 | data>>8 }
 
 // EthernetHandle holds shared buffers and file descriptor of af_packet socket
 type EthernetHandle struct {
-	fd     int
+	fd     uintptr
 	buffer []byte
 	oob    []byte
 	ancil  []interface{}
@@ -46,6 +47,16 @@ func (h *EthernetHandle) readOne() (ci gopacket.CaptureInfo, vlan int, haveVlan 
 	// we could use unix.Recvmsg, but that does a memory allocation (for the returned sockaddr) :(
 	var msg unix.Msghdr
 	var sa unix.RawSockaddrLinklayer
+	var handle = atomic.LoadUintptr(&h.fd)
+
+	/*
+	 * check if the handle got closed already
+	 * if so return EOF to also stop waiting for packets
+	 */
+	if int(handle) < 0 {
+		err = io.EOF
+		return
+	}
 
 	msg.Name = (*byte)(unsafe.Pointer(&sa))
 	msg.Namelen = uint32(unsafe.Sizeof(sa))
@@ -63,11 +74,16 @@ func (h *EthernetHandle) readOne() (ci gopacket.CaptureInfo, vlan int, haveVlan 
 		msg.SetControllen(len(h.oob))
 	}
 
-	// use msg_trunc so we know packet size without auxdata, which might be missing
-	n, _, e := syscall.Syscall(unix.SYS_RECVMSG, uintptr(h.fd), uintptr(unsafe.Pointer(&msg)), uintptr(unix.MSG_TRUNC))
+	/*
+	 * use msg_trunc, so we know packet size without auxdata, which might be missing
+	 */
+	n, _, e := syscall.Syscall(unix.SYS_RECVMSG, handle, uintptr(unsafe.Pointer(&msg)), uintptr(unix.MSG_TRUNC))
 
-	if e != 0 {
-		return gopacket.CaptureInfo{}, 0, false, fmt.Errorf("couldn't read packet: %s", e)
+	switch {
+	case e.Temporary() || e.Timeout():
+		return ci, 0, false, e
+	case e != 0:
+		return ci, 0, false, fmt.Errorf("couldn't read packet: %w", e)
 	}
 
 	if sa.Family == unix.AF_PACKET {
@@ -93,10 +109,10 @@ func (h *EthernetHandle) readOne() (ci gopacket.CaptureInfo, vlan int, haveVlan 
 			gotAux = true
 		case hdr.Level == unix.SOL_SOCKET && hdr.Type == unix.SO_TIMESTAMPNS && len(oob) >= timensLen:
 			tstamp := (*unix.Timespec)(unsafe.Pointer(&oob[hdrLen]))
-			ci.Timestamp = time.Unix(int64(tstamp.Sec), int64(tstamp.Nsec))
+			ci.Timestamp = time.Unix(tstamp.Sec, tstamp.Nsec)
 		case hdr.Level == unix.SOL_SOCKET && hdr.Type == unix.SO_TIMESTAMP && len(oob) >= timeLen:
 			tstamp := (*unix.Timeval)(unsafe.Pointer(&oob[hdrLen]))
-			ci.Timestamp = time.Unix(int64(tstamp.Sec), int64(tstamp.Usec)*1000)
+			ci.Timestamp = time.Unix(tstamp.Sec, int64(tstamp.Usec)*1000)
 		}
 		oob = oob[unix.CmsgSpace(int(hdr.Len))-hdrLen:]
 	}
@@ -160,12 +176,15 @@ func (h *EthernetHandle) ZeroCopyReadPacketData() ([]byte, gopacket.CaptureInfo,
 }
 
 // Close closes the underlying socket
-func (h *EthernetHandle) Close() {
-	if h.fd != -1 {
-		unix.Close(h.fd)
-		h.fd = -1
+func (h *EthernetHandle) Close() (err error) {
+	if handle := atomic.LoadUintptr(&h.fd); handle != 0 {
+		_ = unix.Shutdown(int(handle), unix.SHUT_RDWR)
+		// close no matter if shutdown returned an error or not to make sure the socket is closed
+		err = unix.Close(int(handle))
+		atomic.SwapUintptr(&h.fd, 0)
 		runtime.SetFinalizer(h, nil)
 	}
+	return err
 }
 
 // SetCaptureLength sets the maximum capture length to the given value
@@ -186,7 +205,7 @@ func (h *EthernetHandle) GetCaptureLength() int {
 // If a filter was already attached, it will be overwritten. To remove the filter, provide an empty slice.
 func (h *EthernetHandle) SetBPF(filter []bpf.RawInstruction) error {
 	if len(filter) == 0 {
-		return unix.SetsockoptInt(h.fd, unix.SOL_SOCKET, unix.SO_DETACH_FILTER, 0)
+		return unix.SetsockoptInt(int(h.fd), unix.SOL_SOCKET, unix.SO_DETACH_FILTER, 0)
 	}
 	f := make([]unix.SockFilter, len(filter))
 	for i := range filter {
@@ -199,7 +218,7 @@ func (h *EthernetHandle) SetBPF(filter []bpf.RawInstruction) error {
 		Len:    uint16(len(filter)),
 		Filter: &f[0],
 	}
-	return unix.SetsockoptSockFprog(h.fd, unix.SOL_SOCKET, unix.SO_ATTACH_FILTER, fprog)
+	return unix.SetsockoptSockFprog(int(h.fd), unix.SOL_SOCKET, unix.SO_ATTACH_FILTER, fprog)
 }
 
 // LocalAddr returns the local network address
@@ -224,12 +243,12 @@ func (h *EthernetHandle) SetPromiscuous(b bool) error {
 		opt = unix.PACKET_DROP_MEMBERSHIP
 	}
 
-	return unix.SetsockoptPacketMreq(h.fd, unix.SOL_PACKET, opt, &mreq)
+	return unix.SetsockoptPacketMreq(int(h.fd), unix.SOL_PACKET, opt, &mreq)
 }
 
 // Stats returns number of packets and dropped packets. This will be the number of packets/dropped packets since the last call to stats (not the cummulative sum!).
 func (h *EthernetHandle) Stats() (*unix.TpacketStats, error) {
-	return unix.GetsockoptTpacketStats(h.fd, unix.SOL_PACKET, unix.PACKET_STATISTICS)
+	return unix.GetsockoptTpacketStats(int(h.fd), unix.SOL_PACKET, unix.PACKET_STATISTICS)
 }
 
 // NewEthernetHandle implements pcap.OpenLive for network devices.
@@ -275,7 +294,7 @@ func NewEthernetHandle(ifname string) (*EthernetHandle, error) {
 	}
 
 	handle := &EthernetHandle{
-		fd:     fd,
+		fd:     uintptr(fd),
 		buffer: make([]byte, intf.MTU),
 		oob:    make([]byte, ooblen),
 		ancil:  make([]interface{}, 1),

--- a/pcapgo/capture_test.go
+++ b/pcapgo/capture_test.go
@@ -3,18 +3,29 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file in the root of the source
 // tree.
-//go:build linux && go1.9
-// +build linux,go1.9
+//go:build linux
 
 package pcapgo_test
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"log"
 	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/gopacket/gopacket/pcapgo"
+)
+
+const (
+	timeout = 100 * time.Millisecond
 )
 
 func Example_captureEthernet() {
@@ -34,9 +45,137 @@ func Example_captureEthernet() {
 	}
 
 	pkgsrc := gopacket.NewPacketSource(handle, layers.LayerTypeEthernet)
-	for packet := range pkgsrc.Packets() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for packet := range pkgsrc.PacketsCtx(ctx) {
 		if err := pcapw.WritePacket(packet.Metadata().CaptureInfo, packet.Data()); err != nil {
 			log.Fatalf("pcap.WritePacket(): %v", err)
 		}
 	}
+}
+
+func TestEthernetHandle_Close_WithTimeout(t *testing.T) {
+	var (
+		handle *pcapgo.EthernetHandle
+		err    error
+		done   = make(chan struct{})
+	)
+
+	handle, err = pcapgo.NewEthernetHandle(setupDummyInterface(t))
+	if err != nil {
+		t.Fatalf("OpenEthernet: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	pkgsrc := gopacket.NewPacketSource(handle, layers.LayerTypeEthernet)
+
+	go consumePacketSource(ctx, t, pkgsrc, done)
+
+	select {
+	case _, more := <-done:
+		if more {
+			t.Fatalf("done channel is polluted?!")
+		} else {
+			t.Log("PacketSource got closed")
+		}
+	case <-time.After(2 * timeout):
+	}
+}
+
+func TestEthernetHandle_Close_WithCancel(t *testing.T) {
+	var (
+		handle *pcapgo.EthernetHandle
+		err    error
+		done   = make(chan struct{})
+	)
+
+	handle, err = pcapgo.NewEthernetHandle(setupDummyInterface(t))
+	if err != nil {
+		t.Fatalf("OpenEthernet: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pkgsrc := gopacket.NewPacketSource(handle, layers.LayerTypeEthernet)
+	go consumePacketSource(ctx, t, pkgsrc, done)
+
+	go func() {
+		<-time.After(timeout)
+		cancel()
+	}()
+
+	select {
+	case _, more := <-done:
+		if more {
+			t.Fatalf("done channel is polluted?!")
+		} else {
+			t.Log("PacketSource got closed")
+		}
+	case <-time.After(2 * timeout):
+	}
+}
+
+func consumePacketSource(ctx context.Context, tb testing.TB, pkgsrc *gopacket.PacketSource, done chan<- struct{}) {
+	tb.Helper()
+	var writer = pcapgo.NewWriter(new(bytes.Buffer))
+	defer close(done)
+	for packet := range pkgsrc.PacketsCtx(ctx) {
+		if err := writer.WritePacket(packet.Metadata().CaptureInfo, packet.Data()); err != nil {
+			tb.Errorf("pcap.WritePacket(): %v", err)
+		}
+	}
+}
+
+var (
+	dummyInterfaceIdx int32 = -1
+)
+
+// setupDummyInterface configures a dummy interface and returns the generated interface name.
+// It assigns an address from the 127.10.0.0/24 network.
+// It does not check if there are already more than 254 interfaces.
+// If there are the call to netlink.ParseAddr will fail because 127.10.0.256/24 isn't a valid IP address,
+// but it should be fine for testing purposes.
+func setupDummyInterface(tb testing.TB) (ifName string) {
+	tb.Helper()
+	la := netlink.NewLinkAttrs()
+	idx := atomic.AddInt32(&dummyInterfaceIdx, 1)
+	la.Name = fmt.Sprintf("dummy%02d", idx)
+	dummyInterface := &netlink.Dummy{LinkAttrs: la}
+	if err := netlink.LinkAdd(dummyInterface); err != nil {
+		tb.Fatalf("netlink.LinkAdd() error = %v", err)
+	}
+
+	var (
+		link netlink.Link
+		addr *netlink.Addr
+		err  error
+	)
+
+	link, err = netlink.LinkByName(la.Name)
+	if err != nil {
+		tb.Fatalf("netlink.LinkByName() error = %v", err)
+	}
+
+	tb.Cleanup(func() {
+		if err := netlink.LinkDel(link); err != nil {
+			tb.Fatalf("netlink.LinkDel() error = %v", err)
+		}
+	})
+
+	addr, err = netlink.ParseAddr(fmt.Sprintf("127.10.0.%d/24", idx+1))
+	if err != nil {
+		tb.Fatalf("netlink.ParseAddr() = %v", err)
+	}
+
+	if err := netlink.AddrAdd(link, addr); err != nil {
+		tb.Fatalf("netlink.AddrAdd() error = %v", err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		tb.Fatalf("netlink.LinkSetUp() error = %v", err)
+	}
+
+	return la.Name
 }


### PR DESCRIPTION
I originally prepared this PR for the google/gopacket repo.
Although it's already quite a while I finally managed to re-create it to (hopefully) merge it now :smile:

It's mostly about adding support for `  context.Context`   but I also optimized some small things to avoid allocations in hot paths:

- re-order the IPv4 header parsing
- `  NewZeroCopyPacketSource`  

I'm using these changes already for quite some time so I'm 'optimistic' they're working as expected :smile: 