### PR TITLE
Fix integer size for linux-386 builds

### DIFF
--- a/pcapgo/capture.go
+++ b/pcapgo/capture.go
@@ -109,10 +109,10 @@ func (h *EthernetHandle) readOne() (ci gopacket.CaptureInfo, vlan int, haveVlan 
 			gotAux = true
 		case hdr.Level == unix.SOL_SOCKET && hdr.Type == unix.SO_TIMESTAMPNS && len(oob) >= timensLen:
 			tstamp := (*unix.Timespec)(unsafe.Pointer(&oob[hdrLen]))
-			ci.Timestamp = time.Unix(tstamp.Sec, tstamp.Nsec)
+			ci.Timestamp = time.Unix(int64(tstamp.Sec), int64(tstamp.Nsec))
 		case hdr.Level == unix.SOL_SOCKET && hdr.Type == unix.SO_TIMESTAMP && len(oob) >= timeLen:
 			tstamp := (*unix.Timeval)(unsafe.Pointer(&oob[hdrLen]))
-			ci.Timestamp = time.Unix(tstamp.Sec, int64(tstamp.Usec)*1000)
+			ci.Timestamp = time.Unix(int64(tstamp.Sec), int64(tstamp.Usec)*1000)
 		}
 		oob = oob[unix.CmsgSpace(int(hdr.Len))-hdrLen:]
 	}


### PR DESCRIPTION
We recently switched to this version of `gopacket` and started seeing the following errors when building for `linux-386` targets:

```
Error: /home/runner/go/pkg/mod/github.com/gopacket/gopacket@v1.1.0/pcapgo/capture.go:112:29: cannot use tstamp.Sec (variable of type int32) as int64 value in argument to time.Unix
Error: /home/runner/go/pkg/mod/github.com/gopacket/gopacket@v1.1.0/pcapgo/capture.go:112:41: cannot use tstamp.Nsec (variable of type int32) as int64 value in argument to time.Unix
Error: /home/runner/go/pkg/mod/github.com/gopacket/gopacket@v1.1.0/pcapgo/capture.go:115:29: cannot use tstamp.Sec (variable of type int32) as int64 value in argument to time.Unix
```

This PR fixes the issue by explicitly casting these values to `int64` before use in the `time.Unix` call.