### PR TITLE
Support removing BPF filter from AF_PACKET socket

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -278,6 +278,9 @@ errlbl:
 
 // SetBPF attaches a BPF filter to the underlying socket
 func (h *TPacket) SetBPF(filter []bpf.RawInstruction) error {
+	if len(filter) == 0 {
+		return unix.SetsockoptInt(h.fd, unix.SOL_SOCKET, unix.SO_DETACH_FILTER, 0)
+	}
 	var p unix.SockFprog
 	if len(filter) > int(^uint16(0)) {
 		return errors.New("filter too large")


### PR DESCRIPTION
Do a setsockopt with SO_DETACH_FILTER when TPacket.SetBPF() is called with a empty BPF instruction list.