### PR TITLE
Relax length check on pflog packets

### DIFF
--- a/layers/pflog.go
+++ b/layers/pflog.go
@@ -57,10 +57,10 @@ func (pf *PFLog) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 	pf.RuleUID = binary.BigEndian.Uint32(data[52:56])
 	pf.RulePID = int32(binary.BigEndian.Uint32(data[56:60]))
 	pf.Direction = PFDirection(data[60])
-	if pf.Length%4 != 1 {
-		return errors.New("PFLog header length should be 3 less than multiple of 4")
+	actualLength := int(pf.Length)
+	if pf.Length%4 == 1 {
+		actualLength += 3
 	}
-	actualLength := int(pf.Length) + 3
 	if len(data) < actualLength {
 		return fmt.Errorf("PFLog data size < %d", actualLength)
 	}


### PR DESCRIPTION
OpenBSD pflog adds some fields which aren't present in FreeBSD, as a result the packet's padding is different.

This change was made a long time ago in https://github.com/openbsd/src/commit/72d1fa51d6773e9a0559c1094601272f195c2633

I've brought over the change from https://github.com/google/gopacket/pull/1066, thanks @dennisoelkers for that. This doesn't add parsing for the additional fields (although this commit is enough to unblock the error, you can get the additional fields out of `.Contents` manually, but it might make sense to add them to the layer)