### PR TITLE
Verify checksums

### DIFF
--- a/base.go
+++ b/base.go
@@ -26,6 +26,13 @@ type Layer interface {
 	LayerPayload() []byte
 }
 
+// LayerWithChecksum should be implemented by layers that contain a checksum
+// that can be verified after a packet has been decoded.
+type LayerWithChecksum interface {
+	// VerifyChecksum verifies the checksum and returns the result.
+	VerifyChecksum() (error, ChecksumVerificationResult)
+}
+
 // Payload is a Layer containing the payload of a packet.  The definition of
 // what constitutes the payload of a packet depends on previous layers; for
 // TCP and UDP, we stop decoding above layer 4 and return the remaining

--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,34 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package gopacket
+
+// ComputeChecksum computes the internet checksum as defined in RFC1071. The
+// passed-in csum is any initial checksum data that's already been computed.
+func ComputeChecksum(data []byte, csum uint32) uint32 {
+	// to handle odd lengths, we loop to length - 1, incrementing by 2, then
+	// handle the last byte specifically by checking against the original
+	// length.
+	length := len(data) - 1
+	for i := 0; i < length; i += 2 {
+		// For our test packet, doing this manually is about 25% faster
+		// (740 ns vs. 1000ns) than doing it by calling binary.BigEndian.Uint16.
+		csum += uint32(data[i]) << 8
+		csum += uint32(data[i+1])
+	}
+	if len(data)%2 == 1 {
+		csum += uint32(data[length]) << 8
+	}
+	return csum
+}
+
+// FoldChecksum folds a 32 bit checksum as defined in RFC1071.
+func FoldChecksum(csum uint32) uint16 {
+	for csum > 0xffff {
+		csum = (csum >> 16) + (csum & 0xffff)
+	}
+	return ^uint16(csum)
+}

--- a/checksum.go
+++ b/checksum.go
@@ -6,6 +6,30 @@
 
 package gopacket
 
+// ChecksumVerificationResult provides information about a checksum verification.
+// The checksums are represented using uint32 to fit even the largest checksums.
+// If a checksum is optional and unset, Correct and Actual might mismatch even
+// though Valid is true. In this case, Correct is the computed optional checksum
+// and Actual is 0.
+type ChecksumVerificationResult struct {
+	// Valid tells whether the checksum verification succeeded.
+	Valid bool
+	// Correct is the correct checksum that was expected to be found.
+	Correct uint32
+	// Actual is the checksum that was found and which might be wrong.
+	Actual uint32
+}
+
+// ChecksumMismatch provides information about a failed checksum verification
+// for a layer.
+type ChecksumMismatch struct {
+	ChecksumVerificationResult
+	// Layer is the layer whose checksum is invalid.
+	Layer Layer
+	// LayerIndex is the index of the layer in the packet.
+	LayerIndex int
+}
+
 // ComputeChecksum computes the internet checksum as defined in RFC1071. The
 // passed-in csum is any initial checksum data that's already been computed.
 func ComputeChecksum(data []byte, csum uint32) uint32 {

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,50 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package gopacket
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+// Test the checksum computation helpers using IPv4 packets
+func TestChecksum(t *testing.T) {
+	testData := []struct {
+		name   string
+		header string
+		want   string
+	}{{
+		name:   "sum has two carries",
+		header: "4540005800000000ff11ffff0aeb1d070aed8877",
+		want:   "fffe",
+	}, {
+		name:   "wikipedia case",
+		header: "45000073000040004011b861c0a80001c0a800c7",
+		want:   "b861",
+	}}
+
+	for _, test := range testData {
+		bytes, err := hex.DecodeString(test.header)
+		if err != nil {
+			t.Fatalf("Failed to Decode header: %v", err)
+		}
+		wantBytes, err := hex.DecodeString(test.want)
+		if err != nil {
+			t.Fatalf("Failed to decode want checksum: %v", err)
+		}
+
+		// Clear checksum bytes
+		bytes[10] = 0
+		bytes[11] = 0
+
+		csum := ComputeChecksum(bytes, 0)
+		if got, want := FoldChecksum(csum), binary.BigEndian.Uint16(wantBytes); got != want {
+			t.Errorf("In test %q, got incorrect checksum: got(%x), want(%x)", test.name, got, want)
+		}
+	}
+}

--- a/layers/gre.go
+++ b/layers/gre.go
@@ -176,7 +176,8 @@ func (g *GRE) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 	}
 	if g.ChecksumPresent {
 		if opts.ComputeChecksums {
-			g.Checksum = tcpipChecksum(b.Bytes(), 0)
+			csum := gopacket.ComputeChecksum(b.Bytes(), 0)
+			g.Checksum = gopacket.FoldChecksum(csum)
 		}
 
 		binary.BigEndian.PutUint16(buf[4:6], g.Checksum)

--- a/layers/gre.go
+++ b/layers/gre.go
@@ -195,6 +195,19 @@ func (g *GRE) NextLayerType() gopacket.LayerType {
 	return g.Protocol.LayerType()
 }
 
+func (g *GRE) VerifyChecksum() (error, gopacket.ChecksumVerificationResult) {
+	bytes := append(g.Contents, g.Payload...)
+
+	existing := g.Checksum
+	verification := gopacket.ComputeChecksum(bytes, 0)
+	correct := gopacket.FoldChecksum(verification - uint32(existing))
+	return nil, gopacket.ChecksumVerificationResult{
+		Valid:   !g.ChecksumPresent || correct == existing,
+		Correct: uint32(correct),
+		Actual:  uint32(existing),
+	}
+}
+
 func decodeGRE(data []byte, p gopacket.PacketBuilder) error {
 	g := &GRE{}
 	return decodingLayerDecoder(g, data, p)

--- a/layers/icmp4.go
+++ b/layers/icmp4.go
@@ -245,7 +245,8 @@ func (i *ICMPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 	if opts.ComputeChecksums {
 		bytes[2] = 0
 		bytes[3] = 0
-		i.Checksum = tcpipChecksum(b.Bytes(), 0)
+		csum := gopacket.ComputeChecksum(b.Bytes(), 0)
+		i.Checksum = gopacket.FoldChecksum(csum)
 	}
 	binary.BigEndian.PutUint16(bytes[2:], i.Checksum)
 	return nil

--- a/layers/icmp4.go
+++ b/layers/icmp4.go
@@ -262,6 +262,19 @@ func (i *ICMPv4) NextLayerType() gopacket.LayerType {
 	return gopacket.LayerTypePayload
 }
 
+func (i *ICMPv4) VerifyChecksum() (error, gopacket.ChecksumVerificationResult) {
+	bytes := append(i.Contents, i.Payload...)
+
+	existing := i.Checksum
+	verification := gopacket.ComputeChecksum(bytes, 0)
+	correct := gopacket.FoldChecksum(verification - uint32(existing))
+	return nil, gopacket.ChecksumVerificationResult{
+		Valid:   correct == existing,
+		Correct: uint32(correct),
+		Actual:  uint32(existing),
+	}
+}
+
 func decodeICMPv4(data []byte, p gopacket.PacketBuilder) error {
 	i := &ICMPv4{}
 	return decodingLayerDecoder(i, data, p)

--- a/layers/icmp6.go
+++ b/layers/icmp6.go
@@ -260,6 +260,22 @@ func (i *ICMPv6) NextLayerType() gopacket.LayerType {
 	return gopacket.LayerTypePayload
 }
 
+func (i *ICMPv6) VerifyChecksum() (error, gopacket.ChecksumVerificationResult) {
+	bytes := append(i.Contents, i.Payload...)
+
+	existing := i.Checksum
+	verification, err := i.computeChecksum(bytes, IPProtocolICMPv6)
+	if err != nil {
+		return err, gopacket.ChecksumVerificationResult{}
+	}
+	correct := gopacket.FoldChecksum(verification - uint32(existing))
+	return nil, gopacket.ChecksumVerificationResult{
+		Valid:   correct == existing,
+		Correct: uint32(correct),
+		Actual:  uint32(existing),
+	}
+}
+
 func decodeICMPv6(data []byte, p gopacket.PacketBuilder) error {
 	i := &ICMPv6{}
 	return decodingLayerDecoder(i, data, p)

--- a/layers/icmp6.go
+++ b/layers/icmp6.go
@@ -214,7 +214,7 @@ func (i *ICMPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 		if err != nil {
 			return err
 		}
-		i.Checksum = csum
+		i.Checksum = gopacket.FoldChecksum(csum)
 	}
 	binary.BigEndian.PutUint16(bytes[2:], i.Checksum)
 

--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -311,3 +311,14 @@ func (ip *IPv4) AddressTo4() error {
 	ip.DstIP = dst
 	return nil
 }
+
+func (ip *IPv4) VerifyChecksum() (error, gopacket.ChecksumVerificationResult) {
+	existing := ip.Checksum
+	verification := gopacket.ComputeChecksum(ip.Contents, 0)
+	correct := gopacket.FoldChecksum(verification - uint32(existing))
+	return nil, gopacket.ChecksumVerificationResult{
+		Valid:   correct == existing,
+		Correct: uint32(correct),
+		Actual:  uint32(existing),
+	}
+}

--- a/layers/ip4_test.go
+++ b/layers/ip4_test.go
@@ -10,7 +10,6 @@ package layers
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/hex"
 	"net"
 	"reflect"
@@ -98,38 +97,6 @@ func serialize(ip *IPv4) ([]byte, error) {
 		ComputeChecksums: true,
 	})
 	return buffer.Bytes(), err
-}
-
-// Test the function checksum
-func TestChecksum(t *testing.T) {
-	testData := []struct {
-		name   string
-		header string
-		want   string
-	}{{
-		name:   "sum has two carries",
-		header: "4540005800000000ff11ffff0aeb1d070aed8877",
-		want:   "fffe",
-	}, {
-		name:   "wikipedia case",
-		header: "45000073000040004011b861c0a80001c0a800c7",
-		want:   "b861",
-	}}
-
-	for _, test := range testData {
-		bytes, err := hex.DecodeString(test.header)
-		if err != nil {
-			t.Fatalf("Failed to Decode header: %v", err)
-		}
-		wantBytes, err := hex.DecodeString(test.want)
-		if err != nil {
-			t.Fatalf("Failed to decode want checksum: %v", err)
-		}
-
-		if got, want := checksum(bytes), binary.BigEndian.Uint16(wantBytes); got != want {
-			t.Errorf("In test %q, got incorrect checksum: got(%x), want(%x)", test.name, got, want)
-		}
-	}
 }
 
 func TestIPv4InvalidOptionLength(t *testing.T) {

--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -184,14 +184,18 @@ func (t *TCP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 		if err != nil {
 			return err
 		}
-		t.Checksum = csum
+		t.Checksum = gopacket.FoldChecksum(csum)
 	}
 	binary.BigEndian.PutUint16(bytes[16:], t.Checksum)
 	return nil
 }
 
 func (t *TCP) ComputeChecksum() (uint16, error) {
-	return t.computeChecksum(append(t.Contents, t.Payload...), IPProtocolTCP)
+	csum, err := t.computeChecksum(append(t.Contents, t.Payload...), IPProtocolTCP)
+	if err != nil {
+		return 0, err
+	}
+	return gopacket.FoldChecksum(csum), nil
 }
 
 func (t *TCP) flagsAndOffset() uint16 {

--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -343,3 +343,19 @@ func (t *TCP) SetInternalPortsForTesting() {
 	binary.BigEndian.PutUint16(t.sPort, uint16(t.SrcPort))
 	binary.BigEndian.PutUint16(t.dPort, uint16(t.DstPort))
 }
+
+func (t *TCP) VerifyChecksum() (error, gopacket.ChecksumVerificationResult) {
+	bytes := append(t.Contents, t.Payload...)
+
+	existing := t.Checksum
+	verification, err := t.computeChecksum(bytes, IPProtocolTCP)
+	if err != nil {
+		return err, gopacket.ChecksumVerificationResult{}
+	}
+	correct := gopacket.FoldChecksum(verification - uint32(existing))
+	return nil, gopacket.ChecksumVerificationResult{
+		Valid:   correct == existing,
+		Correct: uint32(correct),
+		Actual:  uint32(existing),
+	}
+}

--- a/layers/tcpip.go
+++ b/layers/tcpip.go
@@ -47,32 +47,11 @@ func (ip *IPv6) pseudoheaderChecksum() (csum uint32, err error) {
 	return csum, nil
 }
 
-// Calculate the TCP/IP checksum defined in rfc1071.  The passed-in csum is any
-// initial checksum data that's already been computed.
-func tcpipChecksum(data []byte, csum uint32) uint16 {
-	// to handle odd lengths, we loop to length - 1, incrementing by 2, then
-	// handle the last byte specifically by checking against the original
-	// length.
-	length := len(data) - 1
-	for i := 0; i < length; i += 2 {
-		// For our test packet, doing this manually is about 25% faster
-		// (740 ns vs. 1000ns) than doing it by calling binary.BigEndian.Uint16.
-		csum += uint32(data[i]) << 8
-		csum += uint32(data[i+1])
-	}
-	if len(data)%2 == 1 {
-		csum += uint32(data[length]) << 8
-	}
-	for csum > 0xffff {
-		csum = (csum >> 16) + (csum & 0xffff)
-	}
-	return ^uint16(csum)
-}
-
 // computeChecksum computes a TCP or UDP checksum.  headerAndPayload is the
 // serialized TCP or UDP header plus its payload, with the checksum zero'd
 // out. headerProtocol is the IP protocol number of the upper-layer header.
-func (c *tcpipchecksum) computeChecksum(headerAndPayload []byte, headerProtocol IPProtocol) (uint16, error) {
+// The returned 32bit checksum may need to be folded.
+func (c *tcpipchecksum) computeChecksum(headerAndPayload []byte, headerProtocol IPProtocol) (uint32, error) {
 	if c.pseudoheader == nil {
 		return 0, errors.New("TCP/IP layer 4 checksum cannot be computed without network layer... call SetNetworkLayerForChecksum to set which layer to use")
 	}
@@ -84,7 +63,9 @@ func (c *tcpipchecksum) computeChecksum(headerAndPayload []byte, headerProtocol 
 	csum += uint32(headerProtocol)
 	csum += length & 0xffff
 	csum += length >> 16
-	return tcpipChecksum(headerAndPayload, csum), nil
+
+	csum = gopacket.ComputeChecksum(headerAndPayload, csum)
+	return csum, nil
 }
 
 // SetNetworkLayerForChecksum tells this layer which network layer is wrapping it.

--- a/layers/udp.go
+++ b/layers/udp.go
@@ -89,6 +89,12 @@ func (u *UDP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 		if err != nil {
 			return err
 		}
+		// RFC768: If the computed checksum is zero, it is transmitted as all ones (the
+		// equivalent in one's complement arithmetic). An all zero transmitted
+		// checksum  value means that the transmitter generated no checksum.
+		if csum == 0 {
+			csum = 0xFFFF
+		}
 		u.Checksum = csum
 	}
 	binary.BigEndian.PutUint16(bytes[6:], u.Checksum)

--- a/layers/udp.go
+++ b/layers/udp.go
@@ -85,17 +85,20 @@ func (u *UDP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 		// zero out checksum bytes
 		bytes[6] = 0
 		bytes[7] = 0
+
 		csum, err := u.computeChecksum(b.Bytes(), IPProtocolUDP)
 		if err != nil {
 			return err
 		}
+		csumFolded := gopacket.FoldChecksum(csum)
+
 		// RFC768: If the computed checksum is zero, it is transmitted as all ones (the
 		// equivalent in one's complement arithmetic). An all zero transmitted
 		// checksum  value means that the transmitter generated no checksum.
-		if csum == 0 {
-			csum = 0xFFFF
+		if csumFolded == 0 {
+			csumFolded = 0xffff
 		}
-		u.Checksum = csum
+		u.Checksum = csumFolded
 	}
 	binary.BigEndian.PutUint16(bytes[6:], u.Checksum)
 	return nil

--- a/layers/udp.go
+++ b/layers/udp.go
@@ -140,3 +140,19 @@ func (u *UDP) SetInternalPortsForTesting() {
 	binary.BigEndian.PutUint16(u.sPort, uint16(u.SrcPort))
 	binary.BigEndian.PutUint16(u.dPort, uint16(u.DstPort))
 }
+
+func (u *UDP) VerifyChecksum() (error, gopacket.ChecksumVerificationResult) {
+	bytes := append(u.Contents, u.Payload...)
+
+	existing := u.Checksum
+	verification, err := u.computeChecksum(bytes, IPProtocolUDP)
+	if err != nil {
+		return err, gopacket.ChecksumVerificationResult{}
+	}
+	correct := gopacket.FoldChecksum(verification - uint32(existing))
+	return nil, gopacket.ChecksumVerificationResult{
+		Valid:   existing == 0 || correct == existing,
+		Correct: uint32(correct),
+		Actual:  uint32(existing),
+	}
+}

--- a/layers/udp_test.go
+++ b/layers/udp_test.go
@@ -8,6 +8,7 @@
 package layers
 
 import (
+	"net"
 	"reflect"
 	"testing"
 
@@ -370,5 +371,38 @@ func TestDNSDoesNotMalloc(t *testing.T) {
 		}
 	}); n > 0 {
 		t.Error(n, "mallocs decoding DNS")
+	}
+}
+
+// RFC768: If the computed checksum is zero, it is transmitted as all ones (the
+// equivalent in one's complement arithmetic). An all zero transmitted
+// checksum  value means that the transmitter generated no checksum.
+func TestZeroChecksum(t *testing.T) {
+	ip := &IPv4{
+		Version: 4,
+		// Choosen to give a 0 checksum.
+		SrcIP:    net.ParseIP("116.43.192.186"),
+		DstIP:    net.ParseIP("8.47.167.201"),
+		Protocol: IPProtocolUDP,
+	}
+	udp := &UDP{
+		SrcPort: 1234,
+		DstPort: 5678,
+	}
+	udp.SetNetworkLayerForChecksum(ip)
+
+	buf := gopacket.NewSerializeBuffer()
+	gopacket.SerializeLayers(buf,
+		gopacket.SerializeOptions{
+			ComputeChecksums: true,
+			FixLengths:       true,
+		},
+		ip,
+		udp,
+	)
+
+	result := gopacket.NewPacket(buf.Bytes(), LayerTypeIPv4, gopacket.Default)
+	if checksum := result.Layer(LayerTypeUDP).(*UDP).Checksum; checksum != 0xFFFF {
+		t.Fatalf("expoected checksum 0xFFFF, got 0x%x", checksum)
 	}
 }


### PR DESCRIPTION
Thank you for forking `google/gopacket` and keeping it alive!

Originally submitted here: https://github.com/google/gopacket/pull/1057
With a commit from: https://github.com/google/gopacket/pull/883

---

This PR adds a LayerWithChecksum interface for layers that have a checksum with a function to verify it and implements this function for all layers that use the internet checksum from RFC1071 and where the checksum computation was implemented (for SerializeTo).

It also adds a way to verify the checksums of all layers of a packet and retrieve a list of all found mismatches.

To implement this, I refactored the internet checksum calculation code, deduplicated it and made it a little bit more modular. There are now two functions: ComputeChecksum and FoldChecksum.
These split-up functions make it possible to verify checksums without having to zero-out the checksum that's already set in the packet. Instead, the checksum of the whole packet (including the existing checksum) is computed and then the existing checksum is subtracted, before it is folded. This way we don't need to copy the packet buffer and zero-out the checksum field, just to verify it.

The refactoring and checksum-verification are split up into two commits to make this easier to review.

For the UDP layer, there is a special case, because the UDP checksum is optional. That's why this PR is based on https://github.com/google/gopacket/pull/883 and extends it to make the checksum verification succeed, if the existing UDP checksum was unset.