### PR TITLE
Address panics found by using fuzzing described in PR#29

### DIFF
--- a/layers/ctp.go
+++ b/layers/ctp.go
@@ -71,6 +71,9 @@ func (c *EthernetCTPReply) LayerType() gopacket.LayerType {
 func (c *EthernetCTPReply) Payload() []byte { return c.Data }
 
 func decodeEthernetCTP(data []byte, p gopacket.PacketBuilder) error {
+	if len(data) < 2 {
+		return fmt.Errorf("EthernetCTP data type too short: %d", len(data))
+	}
 	c := &EthernetCTP{
 		SkipCount: binary.LittleEndian.Uint16(data[:2]),
 		BaseLayer: BaseLayer{data[:2], data[2:]},
@@ -85,6 +88,9 @@ func decodeEthernetCTP(data []byte, p gopacket.PacketBuilder) error {
 // decodeEthernetCTPFromFunctionType reads in the first 2 bytes to determine the EthernetCTP
 // layer type to decode next, then decodes based on that.
 func decodeEthernetCTPFromFunctionType(data []byte, p gopacket.PacketBuilder) error {
+	if len(data) < 4 {
+		return fmt.Errorf("EthernetCTP function type too short: %d", len(data))
+	}
 	function := EthernetCTPFunction(binary.LittleEndian.Uint16(data[:2]))
 	switch function {
 	case EthernetCTPFunctionReply:
@@ -98,6 +104,9 @@ func decodeEthernetCTPFromFunctionType(data []byte, p gopacket.PacketBuilder) er
 		p.SetApplicationLayer(reply)
 		return nil
 	case EthernetCTPFunctionForwardData:
+		if len(data) < 8 {
+			return fmt.Errorf("EthernetCTP ForwardData too short: %d", len(data))
+		}
 		forward := &EthernetCTPForwardData{
 			Function:       function,
 			ForwardAddress: data[2:8],

--- a/layers/etherip.go
+++ b/layers/etherip.go
@@ -8,6 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 
 	"github.com/gopacket/gopacket"
 )
@@ -24,6 +25,9 @@ func (e *EtherIP) LayerType() gopacket.LayerType { return LayerTypeEtherIP }
 
 // DecodeFromBytes decodes the given bytes into this layer.
 func (e *EtherIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 4 {
+		return errors.New("EthernetIP packet too small")
+	}
 	e.Version = data[0] >> 4
 	e.Reserved = binary.BigEndian.Uint16(data[:2]) & 0x0fff
 	e.BaseLayer = BaseLayer{data[:2], data[2:]}

--- a/layers/ipsec.go
+++ b/layers/ipsec.go
@@ -67,6 +67,10 @@ type IPSecESP struct {
 func (i *IPSecESP) LayerType() gopacket.LayerType { return LayerTypeIPSecESP }
 
 func decodeIPSecESP(data []byte, p gopacket.PacketBuilder) error {
+	if len(data) < 8 {
+		p.SetTruncated()
+		return errors.New("IPSec ESP packet less than 8 bytes")
+	}
 	i := &IPSecESP{
 		BaseLayer: BaseLayer{data, nil},
 		SPI:       binary.BigEndian.Uint32(data[:4]),

--- a/layers/ipsec.go
+++ b/layers/ipsec.go
@@ -46,6 +46,9 @@ func decodeIPSecAH(data []byte, p gopacket.PacketBuilder) error {
 	if len(data) < i.ActualLength {
 		p.SetTruncated()
 		return errors.New("Truncated AH packet < ActualLength")
+	} else if i.ActualLength <= 12 {
+		p.SetTruncated()
+		return errors.New("IPSec AH packet with invalid value for ActualLength")
 	}
 	i.AuthenticationData = data[12:i.ActualLength]
 	i.Contents = data[:i.ActualLength]

--- a/layers/mpls.go
+++ b/layers/mpls.go
@@ -56,6 +56,9 @@ func (ProtocolGuessingDecoder) Decode(data []byte, p gopacket.PacketBuilder) err
 var MPLSPayloadDecoder gopacket.Decoder = ProtocolGuessingDecoder{}
 
 func decodeMPLS(data []byte, p gopacket.PacketBuilder) error {
+	if len(data) < 4 {
+		return errors.New("MPLS packet too small")
+	}
 	decoded := binary.BigEndian.Uint32(data[:4])
 	mpls := &MPLS{
 		Label:        decoded >> 12,

--- a/layers/ppp.go
+++ b/layers/ppp.go
@@ -39,13 +39,22 @@ func (p *PPP) LinkFlow() gopacket.Flow { return PPPFlow }
 func decodePPP(data []byte, p gopacket.PacketBuilder) error {
 	ppp := &PPP{}
 	offset := 0
+	if len(data) < 2 {
+		return errors.New("PPP packet too small")
+	}
 	if data[0] == 0xff && data[1] == 0x03 {
 		offset = 2
 		ppp.HasPPTPHeader = true
 	}
+	if len(data) < offset+1 {
+		return errors.New("PPP packet too small")
+	}
 	if data[offset]&0x1 == 0 {
 		if data[offset+1]&0x1 == 0 {
 			return errors.New("PPP has invalid type")
+		}
+		if len(data) < offset+2 {
+			return errors.New("PPP packet too small")
 		}
 		ppp.PPPType = PPPType(binary.BigEndian.Uint16(data[offset : offset+2]))
 		ppp.Contents = data[offset : offset+2]

--- a/layers/ppp.go
+++ b/layers/ppp.go
@@ -46,7 +46,7 @@ func decodePPP(data []byte, p gopacket.PacketBuilder) error {
 		offset = 2
 		ppp.HasPPTPHeader = true
 	}
-	if len(data) < offset+1 {
+	if len(data) < offset+2 {
 		return errors.New("PPP packet too small")
 	}
 	if data[offset]&0x1 == 0 {


### PR DESCRIPTION
This PR addresses additional panics found when fuzzing using the fuzzer added in PR #29.  It does not address all panics but those that I was able to find and fix within the time I had available.

Note that the fuzzer continues to find a new panic immediately upon launch.

Once #29 has landed, the following command will run the fuzzer.
`go test -fuzz '^FuzzNewPacket$' github.com/gopacket/gopacket/layers`