### PR TITLE
Add test for UDPLite, fix panic and protocol issue

### DIFF
--- a/layers/udplite.go
+++ b/layers/udplite.go
@@ -9,6 +9,7 @@ package layers
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/gopacket/gopacket"
 )
@@ -17,7 +18,7 @@ import (
 type UDPLite struct {
 	BaseLayer
 	SrcPort, DstPort UDPLitePort
-	ChecksumCoverage uint16
+	ChecksumCoverage uint16 // 0 = entire packet
 	Checksum         uint16
 	sPort, dPort     []byte
 }
@@ -26,6 +27,10 @@ type UDPLite struct {
 func (u *UDPLite) LayerType() gopacket.LayerType { return LayerTypeUDPLite }
 
 func decodeUDPLite(data []byte, p gopacket.PacketBuilder) error {
+	if len(data) < 9 {
+		p.SetTruncated()
+		return fmt.Errorf("UDP-Lite packet too small")
+	}
 	udp := &UDPLite{
 		SrcPort:          UDPLitePort(binary.BigEndian.Uint16(data[0:2])),
 		sPort:            data[0:2],
@@ -34,6 +39,17 @@ func decodeUDPLite(data []byte, p gopacket.PacketBuilder) error {
 		ChecksumCoverage: binary.BigEndian.Uint16(data[4:6]),
 		Checksum:         binary.BigEndian.Uint16(data[6:8]),
 		BaseLayer:        BaseLayer{data[:8], data[8:]},
+	}
+
+	// UDP-Lite Checksums must at least cover the 8 byte header or must be dropped.
+	if udp.ChecksumCoverage != 0 && udp.ChecksumCoverage < 8 {
+		p.SetTruncated()
+		return fmt.Errorf("UDP-Lite packet has invalid value for Checksum Coverage: %d", udp.ChecksumCoverage)
+	}
+
+	if len(data) < int(udp.ChecksumCoverage) {
+		p.SetTruncated()
+		return fmt.Errorf("UDP-Lite packet has value for Checksum Coverage %d that is larger than the data %d", int(udp.ChecksumCoverage), len(data))
 	}
 	p.AddLayer(udp)
 	p.SetTransportLayer(udp)

--- a/layers/udplite_test.go
+++ b/layers/udplite_test.go
@@ -1,0 +1,121 @@
+// Copyright 2014, Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	_ "fmt"
+	"reflect"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+)
+
+// packet samples from Wireshark sample set: https://wiki.wireshark.org/Lightweight_User_Datagram_Protocol.md
+var udpLiteTestData = map[string]struct {
+	data       []byte
+	wantLayers []gopacket.LayerType
+	want       *UDPLite
+	shouldErr  bool
+}{
+	"udp-lite - valid - full checksum coverage": {
+		data: []byte{
+			// UDP-Lite header
+			0x80, 0x00, 0x04, 0xd2, 0x00, 0x00, 0x38, 0x45,
+			// Payload
+			0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a,
+		},
+		wantLayers: []gopacket.LayerType{LayerTypeUDPLite, gopacket.LayerTypePayload},
+		want: &UDPLite{
+			BaseLayer: BaseLayer{
+				Contents: []uint8{0x80, 0x00, 0x04, 0xd2, 0x00, 0x00, 0x38, 0x45},
+				Payload:  []uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0xa},
+			},
+			SrcPort:          32768,
+			DstPort:          1234,
+			ChecksumCoverage: 0, // 0 = entire packet
+			Checksum:         14405,
+			sPort:            []uint8{0x80, 0x0},
+			dPort:            []uint8{0x4, 0xd2},
+		},
+	},
+	"udp-lite - valid - 20 byte checksum coverage": {
+		data: []byte{
+			// UDP-Lite header
+			0x80, 0x00, 0x04, 0xd2, 0x00, 0x14, 0x38, 0x31,
+			// Payload
+			0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a,
+		},
+		wantLayers: []gopacket.LayerType{LayerTypeUDPLite, gopacket.LayerTypePayload},
+		want: &UDPLite{
+			BaseLayer: BaseLayer{
+				Contents: []uint8{0x80, 0x00, 0x04, 0xd2, 0x00, 0x14, 0x38, 0x31},
+				Payload:  []uint8{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0xa},
+			},
+			SrcPort:          32768,
+			DstPort:          1234,
+			ChecksumCoverage: 20, //
+			Checksum:         0x3831,
+			sPort:            []uint8{0x80, 0x0},
+			dPort:            []uint8{0x4, 0xd2},
+		},
+	},
+	"udp-lite - invalid - checksum coverage exceeds size of data": {
+		data: []byte{
+			// UDP-Lite header
+			0x80, 0x00, 0x04, 0xd2, 0x00, 0x15, 0x38, 0x30,
+			// Payload
+			0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a,
+		},
+		wantLayers: []gopacket.LayerType{},
+		want:       &UDPLite{},
+		shouldErr:  true,
+	},
+	"udp-lite - invalid - checksum coverage doesn't meet minimum req of 8 bytes": {
+		data: []byte{
+			// UDP-Lite header
+			0x80, 0x00, 0x04, 0xd2, 0x00, 0x01, 0xce, 0xef,
+			// Payload
+			0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x0a,
+		},
+		wantLayers: []gopacket.LayerType{},
+		want:       &UDPLite{},
+		shouldErr:  true,
+	},
+}
+
+func TestDecodeUDPLite(t *testing.T) {
+	for label, td := range udpLiteTestData {
+		t.Run(label, func(t *testing.T) {
+			p := gopacket.NewPacket(td.data, LayerTypeUDPLite, gopacket.Default)
+			if p.ErrorLayer() != nil && !td.shouldErr {
+				t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+			} else if p.ErrorLayer() == nil && td.shouldErr {
+				t.Error("expected an error, but got nil")
+			}
+
+			if p.ErrorLayer() != nil || td.shouldErr {
+				return
+			}
+
+			checkLayers(p, td.wantLayers, t)
+
+			if got, ok := p.Layer(LayerTypeUDPLite).(*UDPLite); ok {
+				if !reflect.DeepEqual(got, td.want) {
+					t.Errorf("UDP-Lite packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", got, td.want)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkDecodeUDPLite(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, td := range udpLiteTestData {
+			gopacket.NewPacket(td.data, LayerTypeUDPLite, gopacket.Default)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds tests for the UDP-Lite protocol, fixes a panic due to slicing into data of unverified length, and adds a protocol validity check.

The test corpus is structured in a way so as to make adding the data to a fuzz corpus easier. If PR @29 lands I can update this PR or submit a follow PR to do so.