### PR TITLE
refactor: don't fill empty metadata slots

### DIFF
--- a/layers/enums_generated.go
+++ b/layers/enums_generated.go
@@ -3,7 +3,7 @@
 package layers
 
 // Created by gen2.go, don't edit manually
-// Generated at 2022-08-14 17:04:22.83449 +0200 CEST m=+0.008730827
+// Generated at 2023-09-26 15:45:59.728838421 +0400 +04 m=+0.000090902
 
 import (
 	"fmt"
@@ -12,566 +12,390 @@ import (
 )
 
 func init() {
-	initUnknownTypesForLinkType()
-	initUnknownTypesForEthernetType()
-	initUnknownTypesForPPPType()
-	initUnknownTypesForIPProtocol()
-	initUnknownTypesForSCTPChunkType()
-	initUnknownTypesForPPPoECode()
-	initUnknownTypesForFDDIFrameControl()
-	initUnknownTypesForEAPOLType()
-	initUnknownTypesForProtocolFamily()
-	initUnknownTypesForDot11Type()
-	initUnknownTypesForUSBTransportType()
 	initActualTypeData()
 }
 
 // Decoder calls LinkTypeMetadata.DecodeWith's decoder.
 func (a LinkType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 277 {
-		errDecoder := errorDecoderForLinkType(a)
-		return &errDecoder
+	if int(a) < 277 {
+		if metadata := LinkTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return LinkTypeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode LinkType %d", a)
 }
 
 // String returns LinkTypeMetadata.Name.
 func (a LinkType) String() string {
-	if int(a) >= 277 {
-		return "UnknownLinkType"
+	if int(a) < 277 {
+		if metadata := LinkTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return LinkTypeMetadata[a].Name
+	return "UnknownLinkType"
 }
 
 // LayerType returns LinkTypeMetadata.LayerType.
 func (a LinkType) LayerType() gopacket.LayerType {
-	if int(a) >= 277 {
-		return 0
-	}
-
-	return LinkTypeMetadata[a].LayerType
-}
-
-type errorDecoderForLinkType int
-
-func (a *errorDecoderForLinkType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForLinkType) Error() string {
-	return fmt.Sprintf("Unable to decode LinkType %d", int(*a))
-}
-
-var errorDecodersForLinkType [277]errorDecoderForLinkType
-var LinkTypeMetadata [277]EnumMetadata
-
-func initUnknownTypesForLinkType() {
-	for i := 0; i < 277; i++ {
-		errorDecodersForLinkType[i] = errorDecoderForLinkType(i)
-		LinkTypeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForLinkType[i],
-			Name:       "UnknownLinkType",
+	if int(a) < 277 {
+		if metadata := LinkTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var LinkTypeMetadata [277]EnumMetadata
 
 // Decoder calls EthernetTypeMetadata.DecodeWith's decoder.
 func (a EthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 65536 {
-		errDecoder := errorDecoderForEthernetType(a)
-		return &errDecoder
+	if int(a) < 65536 {
+		if metadata := EthernetTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return EthernetTypeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode EthernetType %d", a)
 }
 
 // String returns EthernetTypeMetadata.Name.
 func (a EthernetType) String() string {
-	if int(a) >= 65536 {
-		return "UnknownEthernetType"
+	if int(a) < 65536 {
+		if metadata := EthernetTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return EthernetTypeMetadata[a].Name
+	return "UnknownEthernetType"
 }
 
 // LayerType returns EthernetTypeMetadata.LayerType.
 func (a EthernetType) LayerType() gopacket.LayerType {
-	if int(a) >= 65536 {
-		return 0
-	}
-
-	return EthernetTypeMetadata[a].LayerType
-}
-
-type errorDecoderForEthernetType int
-
-func (a *errorDecoderForEthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForEthernetType) Error() string {
-	return fmt.Sprintf("Unable to decode EthernetType %d", int(*a))
-}
-
-var errorDecodersForEthernetType [65536]errorDecoderForEthernetType
-var EthernetTypeMetadata [65536]EnumMetadata
-
-func initUnknownTypesForEthernetType() {
-	for i := 0; i < 65536; i++ {
-		errorDecodersForEthernetType[i] = errorDecoderForEthernetType(i)
-		EthernetTypeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForEthernetType[i],
-			Name:       "UnknownEthernetType",
+	if int(a) < 65536 {
+		if metadata := EthernetTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var EthernetTypeMetadata [65536]EnumMetadata
 
 // Decoder calls PPPTypeMetadata.DecodeWith's decoder.
 func (a PPPType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 65536 {
-		errDecoder := errorDecoderForPPPType(a)
-		return &errDecoder
+	if int(a) < 65536 {
+		if metadata := PPPTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return PPPTypeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode PPPType %d", a)
 }
 
 // String returns PPPTypeMetadata.Name.
 func (a PPPType) String() string {
-	if int(a) >= 65536 {
-		return "UnknownPPPType"
+	if int(a) < 65536 {
+		if metadata := PPPTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return PPPTypeMetadata[a].Name
+	return "UnknownPPPType"
 }
 
 // LayerType returns PPPTypeMetadata.LayerType.
 func (a PPPType) LayerType() gopacket.LayerType {
-	if int(a) >= 65536 {
-		return 0
-	}
-
-	return PPPTypeMetadata[a].LayerType
-}
-
-type errorDecoderForPPPType int
-
-func (a *errorDecoderForPPPType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForPPPType) Error() string {
-	return fmt.Sprintf("Unable to decode PPPType %d", int(*a))
-}
-
-var errorDecodersForPPPType [65536]errorDecoderForPPPType
-var PPPTypeMetadata [65536]EnumMetadata
-
-func initUnknownTypesForPPPType() {
-	for i := 0; i < 65536; i++ {
-		errorDecodersForPPPType[i] = errorDecoderForPPPType(i)
-		PPPTypeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForPPPType[i],
-			Name:       "UnknownPPPType",
+	if int(a) < 65536 {
+		if metadata := PPPTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var PPPTypeMetadata [65536]EnumMetadata
 
 // Decoder calls IPProtocolMetadata.DecodeWith's decoder.
 func (a IPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForIPProtocol(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := IPProtocolMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return IPProtocolMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode IPProtocol %d", a)
 }
 
 // String returns IPProtocolMetadata.Name.
 func (a IPProtocol) String() string {
-	if int(a) >= 256 {
-		return "UnknownIPProtocol"
+	if int(a) < 256 {
+		if metadata := IPProtocolMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return IPProtocolMetadata[a].Name
+	return "UnknownIPProtocol"
 }
 
 // LayerType returns IPProtocolMetadata.LayerType.
 func (a IPProtocol) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return IPProtocolMetadata[a].LayerType
-}
-
-type errorDecoderForIPProtocol int
-
-func (a *errorDecoderForIPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForIPProtocol) Error() string {
-	return fmt.Sprintf("Unable to decode IPProtocol %d", int(*a))
-}
-
-var errorDecodersForIPProtocol [256]errorDecoderForIPProtocol
-var IPProtocolMetadata [256]EnumMetadata
-
-func initUnknownTypesForIPProtocol() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForIPProtocol[i] = errorDecoderForIPProtocol(i)
-		IPProtocolMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForIPProtocol[i],
-			Name:       "UnknownIPProtocol",
+	if int(a) < 256 {
+		if metadata := IPProtocolMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var IPProtocolMetadata [256]EnumMetadata
 
 // Decoder calls SCTPChunkTypeMetadata.DecodeWith's decoder.
 func (a SCTPChunkType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForSCTPChunkType(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := SCTPChunkTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return SCTPChunkTypeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode SCTPChunkType %d", a)
 }
 
 // String returns SCTPChunkTypeMetadata.Name.
 func (a SCTPChunkType) String() string {
-	if int(a) >= 256 {
-		return "UnknownSCTPChunkType"
+	if int(a) < 256 {
+		if metadata := SCTPChunkTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return SCTPChunkTypeMetadata[a].Name
+	return "UnknownSCTPChunkType"
 }
 
 // LayerType returns SCTPChunkTypeMetadata.LayerType.
 func (a SCTPChunkType) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return SCTPChunkTypeMetadata[a].LayerType
-}
-
-type errorDecoderForSCTPChunkType int
-
-func (a *errorDecoderForSCTPChunkType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForSCTPChunkType) Error() string {
-	return fmt.Sprintf("Unable to decode SCTPChunkType %d", int(*a))
-}
-
-var errorDecodersForSCTPChunkType [256]errorDecoderForSCTPChunkType
-var SCTPChunkTypeMetadata [256]EnumMetadata
-
-func initUnknownTypesForSCTPChunkType() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForSCTPChunkType[i] = errorDecoderForSCTPChunkType(i)
-		SCTPChunkTypeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForSCTPChunkType[i],
-			Name:       "UnknownSCTPChunkType",
+	if int(a) < 256 {
+		if metadata := SCTPChunkTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var SCTPChunkTypeMetadata [256]EnumMetadata
 
 // Decoder calls PPPoECodeMetadata.DecodeWith's decoder.
 func (a PPPoECode) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForPPPoECode(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := PPPoECodeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return PPPoECodeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode PPPoECode %d", a)
 }
 
 // String returns PPPoECodeMetadata.Name.
 func (a PPPoECode) String() string {
-	if int(a) >= 256 {
-		return "UnknownPPPoECode"
+	if int(a) < 256 {
+		if metadata := PPPoECodeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return PPPoECodeMetadata[a].Name
+	return "UnknownPPPoECode"
 }
 
 // LayerType returns PPPoECodeMetadata.LayerType.
 func (a PPPoECode) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return PPPoECodeMetadata[a].LayerType
-}
-
-type errorDecoderForPPPoECode int
-
-func (a *errorDecoderForPPPoECode) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForPPPoECode) Error() string {
-	return fmt.Sprintf("Unable to decode PPPoECode %d", int(*a))
-}
-
-var errorDecodersForPPPoECode [256]errorDecoderForPPPoECode
-var PPPoECodeMetadata [256]EnumMetadata
-
-func initUnknownTypesForPPPoECode() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForPPPoECode[i] = errorDecoderForPPPoECode(i)
-		PPPoECodeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForPPPoECode[i],
-			Name:       "UnknownPPPoECode",
+	if int(a) < 256 {
+		if metadata := PPPoECodeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var PPPoECodeMetadata [256]EnumMetadata
 
 // Decoder calls FDDIFrameControlMetadata.DecodeWith's decoder.
 func (a FDDIFrameControl) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForFDDIFrameControl(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := FDDIFrameControlMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return FDDIFrameControlMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode FDDIFrameControl %d", a)
 }
 
 // String returns FDDIFrameControlMetadata.Name.
 func (a FDDIFrameControl) String() string {
-	if int(a) >= 256 {
-		return "UnknownFDDIFrameControl"
+	if int(a) < 256 {
+		if metadata := FDDIFrameControlMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return FDDIFrameControlMetadata[a].Name
+	return "UnknownFDDIFrameControl"
 }
 
 // LayerType returns FDDIFrameControlMetadata.LayerType.
 func (a FDDIFrameControl) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return FDDIFrameControlMetadata[a].LayerType
-}
-
-type errorDecoderForFDDIFrameControl int
-
-func (a *errorDecoderForFDDIFrameControl) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForFDDIFrameControl) Error() string {
-	return fmt.Sprintf("Unable to decode FDDIFrameControl %d", int(*a))
-}
-
-var errorDecodersForFDDIFrameControl [256]errorDecoderForFDDIFrameControl
-var FDDIFrameControlMetadata [256]EnumMetadata
-
-func initUnknownTypesForFDDIFrameControl() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForFDDIFrameControl[i] = errorDecoderForFDDIFrameControl(i)
-		FDDIFrameControlMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForFDDIFrameControl[i],
-			Name:       "UnknownFDDIFrameControl",
+	if int(a) < 256 {
+		if metadata := FDDIFrameControlMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var FDDIFrameControlMetadata [256]EnumMetadata
 
 // Decoder calls EAPOLTypeMetadata.DecodeWith's decoder.
 func (a EAPOLType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForEAPOLType(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := EAPOLTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return EAPOLTypeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode EAPOLType %d", a)
 }
 
 // String returns EAPOLTypeMetadata.Name.
 func (a EAPOLType) String() string {
-	if int(a) >= 256 {
-		return "UnknownEAPOLType"
+	if int(a) < 256 {
+		if metadata := EAPOLTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return EAPOLTypeMetadata[a].Name
+	return "UnknownEAPOLType"
 }
 
 // LayerType returns EAPOLTypeMetadata.LayerType.
 func (a EAPOLType) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return EAPOLTypeMetadata[a].LayerType
-}
-
-type errorDecoderForEAPOLType int
-
-func (a *errorDecoderForEAPOLType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForEAPOLType) Error() string {
-	return fmt.Sprintf("Unable to decode EAPOLType %d", int(*a))
-}
-
-var errorDecodersForEAPOLType [256]errorDecoderForEAPOLType
-var EAPOLTypeMetadata [256]EnumMetadata
-
-func initUnknownTypesForEAPOLType() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForEAPOLType[i] = errorDecoderForEAPOLType(i)
-		EAPOLTypeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForEAPOLType[i],
-			Name:       "UnknownEAPOLType",
+	if int(a) < 256 {
+		if metadata := EAPOLTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var EAPOLTypeMetadata [256]EnumMetadata
 
 // Decoder calls ProtocolFamilyMetadata.DecodeWith's decoder.
 func (a ProtocolFamily) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForProtocolFamily(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := ProtocolFamilyMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return ProtocolFamilyMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode ProtocolFamily %d", a)
 }
 
 // String returns ProtocolFamilyMetadata.Name.
 func (a ProtocolFamily) String() string {
-	if int(a) >= 256 {
-		return "UnknownProtocolFamily"
+	if int(a) < 256 {
+		if metadata := ProtocolFamilyMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return ProtocolFamilyMetadata[a].Name
+	return "UnknownProtocolFamily"
 }
 
 // LayerType returns ProtocolFamilyMetadata.LayerType.
 func (a ProtocolFamily) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return ProtocolFamilyMetadata[a].LayerType
-}
-
-type errorDecoderForProtocolFamily int
-
-func (a *errorDecoderForProtocolFamily) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForProtocolFamily) Error() string {
-	return fmt.Sprintf("Unable to decode ProtocolFamily %d", int(*a))
-}
-
-var errorDecodersForProtocolFamily [256]errorDecoderForProtocolFamily
-var ProtocolFamilyMetadata [256]EnumMetadata
-
-func initUnknownTypesForProtocolFamily() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForProtocolFamily[i] = errorDecoderForProtocolFamily(i)
-		ProtocolFamilyMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForProtocolFamily[i],
-			Name:       "UnknownProtocolFamily",
+	if int(a) < 256 {
+		if metadata := ProtocolFamilyMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var ProtocolFamilyMetadata [256]EnumMetadata
 
 // Decoder calls Dot11TypeMetadata.DecodeWith's decoder.
 func (a Dot11Type) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForDot11Type(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := Dot11TypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return Dot11TypeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode Dot11Type %d", a)
 }
 
 // String returns Dot11TypeMetadata.Name.
 func (a Dot11Type) String() string {
-	if int(a) >= 256 {
-		return "UnknownDot11Type"
+	if int(a) < 256 {
+		if metadata := Dot11TypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return Dot11TypeMetadata[a].Name
+	return "UnknownDot11Type"
 }
 
 // LayerType returns Dot11TypeMetadata.LayerType.
 func (a Dot11Type) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return Dot11TypeMetadata[a].LayerType
-}
-
-type errorDecoderForDot11Type int
-
-func (a *errorDecoderForDot11Type) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForDot11Type) Error() string {
-	return fmt.Sprintf("Unable to decode Dot11Type %d", int(*a))
-}
-
-var errorDecodersForDot11Type [256]errorDecoderForDot11Type
-var Dot11TypeMetadata [256]EnumMetadata
-
-func initUnknownTypesForDot11Type() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForDot11Type[i] = errorDecoderForDot11Type(i)
-		Dot11TypeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForDot11Type[i],
-			Name:       "UnknownDot11Type",
+	if int(a) < 256 {
+		if metadata := Dot11TypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var Dot11TypeMetadata [256]EnumMetadata
 
 // Decoder calls USBTransportTypeMetadata.DecodeWith's decoder.
 func (a USBTransportType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	if int(a) >= 256 {
-		errDecoder := errorDecoderForUSBTransportType(a)
-		return &errDecoder
+	if int(a) < 256 {
+		if metadata := USBTransportTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.DecodeWith.Decode(data, p)
+		}
 	}
 
-	return USBTransportTypeMetadata[a].DecodeWith.Decode(data, p)
+	return fmt.Errorf("Unable to decode USBTransportType %d", a)
 }
 
 // String returns USBTransportTypeMetadata.Name.
 func (a USBTransportType) String() string {
-	if int(a) >= 256 {
-		return "UnknownUSBTransportType"
+	if int(a) < 256 {
+		if metadata := USBTransportTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.Name
+		}
 	}
 
-	return USBTransportTypeMetadata[a].Name
+	return "UnknownUSBTransportType"
 }
 
 // LayerType returns USBTransportTypeMetadata.LayerType.
 func (a USBTransportType) LayerType() gopacket.LayerType {
-	if int(a) >= 256 {
-		return 0
-	}
-
-	return USBTransportTypeMetadata[a].LayerType
-}
-
-type errorDecoderForUSBTransportType int
-
-func (a *errorDecoderForUSBTransportType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return a
-}
-func (a *errorDecoderForUSBTransportType) Error() string {
-	return fmt.Sprintf("Unable to decode USBTransportType %d", int(*a))
-}
-
-var errorDecodersForUSBTransportType [256]errorDecoderForUSBTransportType
-var USBTransportTypeMetadata [256]EnumMetadata
-
-func initUnknownTypesForUSBTransportType() {
-	for i := 0; i < 256; i++ {
-		errorDecodersForUSBTransportType[i] = errorDecoderForUSBTransportType(i)
-		USBTransportTypeMetadata[i] = EnumMetadata{
-			DecodeWith: &errorDecodersForUSBTransportType[i],
-			Name:       "UnknownUSBTransportType",
+	if int(a) < 256 {
+		if metadata := USBTransportTypeMetadata[a]; metadata.DecodeWith != nil {
+			return metadata.LayerType
 		}
 	}
+
+	return 0
 }
+
+var USBTransportTypeMetadata [256]EnumMetadata


### PR DESCRIPTION
Some metadata arrays are pretty big (e.g. `EthernetTypeMetadata` has 65536 slots), while only a small subset of the values are filled with actual decoders (e.g. for `EthernetTypeMetadata` that is 18 entries).

The rest were filled in `func init()` to return error on access. This leads to noticeable startup time delay, as these mappings are pretty big.

This change simply leaves not used slots unset (zero value), and the request error values are generated on access to the slot.

Comparing time with `GODEBUG=inittrace=1` on a simple test program which imports `gopacket/layers`:

before:

```
init internal/bytealg @0 ms, 0 ms clock, 0 bytes, 0 allocs
init runtime @0.009 ms, 0.063 ms clock, 0 bytes, 0 allocs
init math @0.18 ms, 0 ms clock, 0 bytes, 0 allocs
init errors @0.19 ms, 0 ms clock, 0 bytes, 0 allocs
init sync @0.20 ms, 0.002 ms clock, 16 bytes, 1 allocs
init internal/godebug @0.21 ms, 0.020 ms clock, 816 bytes, 20 allocs
init internal/intern @0.23 ms, 0.002 ms clock, 408 bytes, 8 allocs
init hash/crc32 @0.24 ms, 0.008 ms clock, 1024 bytes, 1 allocs
init net/netip @0.26 ms, 0 ms clock, 48 bytes, 2 allocs
init syscall @0.26 ms, 0.003 ms clock, 640 bytes, 3 allocs
init time @0.27 ms, 0.002 ms clock, 0 bytes, 0 allocs
init context @0.28 ms, 0 ms clock, 96 bytes, 1 allocs
init io/fs @0.29 ms, 0 ms clock, 0 bytes, 0 allocs
init os @0.30 ms, 0.006 ms clock, 328 bytes, 7 allocs
init unicode @0.31 ms, 0 ms clock, 512 bytes, 4 allocs
init reflect @0.32 ms, 0 ms clock, 0 bytes, 0 allocs
init vendor/golang.org/x/net/dns/dnsmessage @0.32 ms, 0.002 ms clock, 624 bytes, 6 allocs
init net @0.33 ms, 0.002 ms clock, 688 bytes, 13 allocs
init github.com/gopacket/gopacket @0.34 ms, 0.003 ms clock, 720 bytes, 5 allocs
init github.com/gopacket/gopacket/layers @0.35 ms, 1.3 ms clock, 25136 bytes, 63 allocs
```

after:

```
init internal/bytealg @0 ms, 0 ms clock, 0 bytes, 0 allocs
init runtime @0.011 ms, 0.070 ms clock, 0 bytes, 0 allocs
init math @0.26 ms, 0 ms clock, 0 bytes, 0 allocs
init errors @0.27 ms, 0 ms clock, 0 bytes, 0 allocs
init sync @0.27 ms, 0.003 ms clock, 16 bytes, 1 allocs
init internal/godebug @0.28 ms, 0.023 ms clock, 816 bytes, 20 allocs
init internal/intern @0.31 ms, 0.002 ms clock, 408 bytes, 8 allocs
init hash/crc32 @0.32 ms, 0.008 ms clock, 1024 bytes, 1 allocs
init net/netip @0.33 ms, 0 ms clock, 48 bytes, 2 allocs
init syscall @0.34 ms, 0.003 ms clock, 640 bytes, 3 allocs
init time @0.35 ms, 0.003 ms clock, 0 bytes, 0 allocs
init context @0.37 ms, 0 ms clock, 96 bytes, 1 allocs
init io/fs @0.38 ms, 0 ms clock, 0 bytes, 0 allocs
init os @0.38 ms, 0.009 ms clock, 328 bytes, 7 allocs
init unicode @0.40 ms, 0 ms clock, 512 bytes, 4 allocs
init reflect @0.41 ms, 0 ms clock, 0 bytes, 0 allocs
init vendor/golang.org/x/net/dns/dnsmessage @0.42 ms, 0.002 ms clock, 624 bytes, 6 allocs
init net @0.43 ms, 0.004 ms clock, 688 bytes, 13 allocs
init github.com/gopacket/gopacket @0.44 ms, 0.003 ms clock, 720 bytes, 5 allocs
init github.com/gopacket/gopacket/layers @0.46 ms, 0.086 ms clock, 25872 bytes, 66 allocs
```