### PR TITLE
allow tcp stream creation prevention

### DIFF
--- a/reassembly/memory.go
+++ b/reassembly/memory.go
@@ -190,6 +190,9 @@ func (p *StreamPool) getConnection(k key, end bool, ts time.Time, tcp *layers.TC
 		return conn, half, rev
 	}
 	s := p.factory.New(k[0], k[1], tcp, ac)
+	if s == nil {
+		return nil, nil, nil
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	conn, half, rev = p.newConnection(k, s, ts)


### PR DESCRIPTION
Allow `New` to return nil to prevent stream creation. 
Useful in case when the stream is reopened because of last ACK.
This addresses this issue: https://github.com/google/gopacket/issues/427 