### PR TITLE
Fix RadioTap decoding panic

### DIFF
--- a/layers/radiotap_test.go
+++ b/layers/radiotap_test.go
@@ -80,3 +80,30 @@ func BenchmarkDecodePacketRadiotap1(b *testing.B) {
 		gopacket.NewPacket(testPacketRadiotap1, LayerTypeRadioTap, gopacket.NoCopy)
 	}
 }
+
+// testPacketRadiotap2 is the packet:
+//
+//	09:34:34.799438 1.0 Mb/s 2412 MHz 11b -58dB signal antenna 7 Acknowledgment RA:88:1f:a1:ae:9d:cb
+//	   0x0000:  0000 ff00 2e48 0000 1002 6c09 a000 c607  .....H....l.....
+//	   0x0010:  0000 d400 0000 881f a1ae 9dcb c630 4b4b  .............0KK
+//
+// Test when the RadioTap size is too large, but still process the RadioTap
+var testPacketRadiotap2 = []byte{
+	0x00, 0x00, 0xff, 0x00, 0x2e, 0x48, 0x00, 0x00, 0x10, 0x02, 0x6c, 0x09, 0xa0, 0x00, 0xc6, 0x07,
+	0x00, 0x00, 0xd4, 0x00, 0x00, 0x00, 0x88, 0x1f, 0xa1, 0xae, 0x9d, 0xcb, 0xc6, 0x30, 0x4b, 0x4b,
+}
+
+func TestPacketRadiotap2(t *testing.T) {
+	p := gopacket.NewPacket(testPacketRadiotap2, LayerTypeRadioTap, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeRadioTap}, t)
+	rt := p.Layer(LayerTypeRadioTap).(*RadioTap)
+	if rt.ChannelFrequency != 2412 || rt.DBMAntennaSignal != -58 || rt.Antenna != 7 {
+		t.Error("Radiotap decode error")
+	}
+	if rt.Rate != 2 { // 500Kbps unit
+		t.Error("Radiotap Rate decode error")
+	}
+}


### PR DESCRIPTION
On rare occasions, it is possible that the length field in the RadioTap layer is bigger than the actual data length which results in a panic when trying to reference the payload. If it's bigger, simply truncate the RadioTap length to the length of the actual data to allow processing of what we can safely.