### PR TITLE
Fix time type when build with _TIME_BITS=64 on 32bit arch

### DIFF
--- a/pcap/pcap_unix.go
+++ b/pcap/pcap_unix.go
@@ -113,8 +113,13 @@ int pcap_tstamp_type_name_to_val(const char* t) {
 #define gopacket_time_secs_t __kernel_time_t
 #define gopacket_time_usecs_t __kernel_suseconds_t
 #elif __GLIBC__
+#ifndef __USE_TIME_BITS64
 #define gopacket_time_secs_t __time_t
 #define gopacket_time_usecs_t __suseconds_t
+#else
+#define gopacket_time_secs_t __time64_t
+#define gopacket_time_usecs_t __suseconds64_t
+#endif
 #else  // Some form of linux/bsd/etc...
 #include <sys/param.h>
 #ifdef __OpenBSD__


### PR DESCRIPTION
Otherwise it results

```
# github.com/gopacket/gopacket/pcap
src/github.com/gopacket/gopacket/pcap/pcap_unix.go:345:18: cannot use _Ctype_gopacket_time_secs_t(ci.Timestamp.Unix()) (value of type _Ctype_long) as _Ctype_longlong value in assignment
src/github.com/gopacket/gopacket/pcap/pcap_unix.go:346:19: cannot use _Ctype_gopacket_time_usecs_t(ci.Timestamp.Nanosecond() / 1000) (value of type _Ctype_long) as _Ctype_longlong value in assignment
```