### PR TITLE
tcp: add support for MPTCP option

### DIFF
--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -54,6 +54,7 @@ const (
 	TCPOptionKindCCEcho                          = 13 // obsolete
 	TCPOptionKindAltChecksum                     = 14 // len = 3, obsolete
 	TCPOptionKindAltChecksumData                 = 15 // len = n, obsolete
+	TCPOptionKindMPTCP                           = 30 // len = n
 )
 
 func (k TCPOptionKind) String() string {
@@ -90,6 +91,8 @@ func (k TCPOptionKind) String() string {
 		return "AltChecksum"
 	case TCPOptionKindAltChecksumData:
 		return "AltChecksumData"
+	case TCPOptionKindMPTCP:
+		return "MPTCP"
 	default:
 		return fmt.Sprintf("Unknown(%d)", k)
 	}


### PR DESCRIPTION
Hello,

First, thank you for developing and maintaining this useful lib!

Currently, packets with MPTCP options are not recognised:

    Unknown(30)

MPTCP packets are using the option 30 according to the [IANA](https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xhtml).

For more details about MPTCP:
- [RFC 8684](https://datatracker.ietf.org/doc/html/rfc8684)
- Website: https://www.mptcp.dev