### PR TITLE
Fix Dot11InformationElement processing

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -1470,11 +1470,13 @@ func (m *Dot11InformationElement) DecodeFromBytes(data []byte, df gopacket.Decod
 		df.SetTruncated()
 		return fmt.Errorf("Dot11InformationElement length %v too short, %v required", len(data), offset+int(m.Length))
 	}
-	if len(data) < offset+4 {
-		df.SetTruncated()
-		return fmt.Errorf("vendor extension size < %d", offset+int(m.Length))
-	}
+
 	if m.ID == 221 {
+		if len(data) < offset+4 {
+			df.SetTruncated()
+			return fmt.Errorf("vendor extension size < %d", offset+int(m.Length))
+		}
+
 		// Vendor extension
 		m.OUI = data[offset : offset+4]
 		m.Info = data[offset+4 : offset+int(m.Length)]


### PR DESCRIPTION
Move offset check within check for vendor extension (221) as this appears to be a bug as the else statement never uses . Previously this would cause small elements to fail processing as it wasn't limited to only vendor elements.

Small Dot11InformationElements that were failing included:

```
Tag: Power Constraint: 0
    Tag Number: Power Constraint (32)
    Tag length: 1
    Local Power Constraint: 0
// 0x20, 0x01, 0x00
```
and 
```
Tag: ERP Information
    Tag Number: ERP Information (47)
    Tag length: 1
    ERP Information: 0x00

// 0x2f, 0x01, 0x00
```

The `len(data) < offset+4` is a valid check, but _only_ for a vendor specific element such as:

```
Tag: Vendor Specific: Broadcom
    Tag Number: Vendor Specific (221)
    Tag length: 9
    OUI: 00:10:18 (Broadcom)
    Vendor Specific OUI Type: 2
    Vendor Specific Data: 0201000c0000

// 0xdd, 0x09, 0x00, 0x10, 0x18, 0x02, 0x01, 0x00, 0x0c, 0x00, 0x00
```
As other elements don't contain this OUI+Type.