### PR TITLE
Add MPTCP Options in the TCP Layer Decoder

### DIFF
--- a/layers/.lint_blacklist
+++ b/layers/.lint_blacklist
@@ -15,6 +15,7 @@ linux_sll.go
 llc.go
 lldp.go
 mpls.go
+multipathtcp.go
 ndp.go
 ntp.go
 ospf.go

--- a/layers/multipathtcp.go
+++ b/layers/multipathtcp.go
@@ -1,0 +1,161 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"fmt"
+	"net"
+)
+
+// MPTCPSubtype represents an MPTCP subtype code.
+type MPTCPSubtype uint8
+
+// MPTCP Subtypes constonts from https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xml#mptcp-option-subtypes
+const (
+	MPTCPSubtypeMPCAPABLE   = 0x0
+	MPTCPSubtypeMPJOIN      = 0x1
+	MPTCPSubtypeDSS         = 0x2
+	MPTCPSubtypeADDADDR     = 0x3
+	MPTCPSubtypeREMOVEADDR  = 0x4
+	MPTCPSubtypeMPPRIO      = 0x5
+	MPTCPSubtypeMPFAIL      = 0x6
+	MPTCPSubtypeMPFASTCLOSE = 0x7
+	MPTCPSubtypeMPTCPRST    = 0x8
+)
+
+func (k MPTCPSubtype) String() string {
+	switch k {
+	case MPTCPSubtypeMPCAPABLE:
+		return "MP_CAPABLE"
+	case MPTCPSubtypeMPJOIN:
+		return "MP_JOIN"
+	case MPTCPSubtypeDSS:
+		return "DSS"
+	case MPTCPSubtypeADDADDR:
+		return "ADD_ADDR"
+	case MPTCPSubtypeREMOVEADDR:
+		return "REMOVE_ADDR"
+	case MPTCPSubtypeMPPRIO:
+		return "MP_PRIO"
+	case MPTCPSubtypeMPFAIL:
+		return "MP_FAIL"
+	case MPTCPSubtypeMPFASTCLOSE:
+		return "MP_FASTCLOSE"
+	case MPTCPSubtypeMPTCPRST:
+		return "MP_TCPRST"
+	default:
+		return fmt.Sprintf("Unknown(%d)", k)
+	}
+}
+
+const (
+	MptcpVersion0 = 0
+	MptcpVersion1 = 1
+)
+
+const (
+	OptionLenMpCapableSyn         = 4
+	OptionLenMpCapableSynAck      = 12
+	OptionLenMpCapableAck         = 20
+	OptionLenMpCapableAckData     = 22
+	OptionLenMpCapableAckDataCSum = 24
+	OptionLenMpJoinSyn            = 12
+	OptionLenMpJoinSynAck         = 16
+	OptionLenMpJoinAck            = 24
+	OptionLenDssAck               = 4
+	OptionLenDssAck64             = 8
+	OptionLenDssDSN               = 4
+	OptionLenDssDSN64             = 8
+	OptionLenDssSSN               = 4
+	OptionLenDssDataLen           = 2
+	OptionLenDssCSum              = 2
+	OptionLenAddAddrv4            = 8
+	OptionLenAddAddrv6            = 20
+	OptionLenAddAddrPort          = 2
+	OptionLenAddAddrHmac          = 8
+	OptionLenRemAddr              = 4
+	OptionLenMpPrio               = 3
+	OptionLenMpPrioAddr           = 4
+	OptionLenMpFail               = 12
+	OptionLenMpFClose             = 12
+	OptionLenMpTcpRst             = 4
+)
+
+// MPCapable contains the fields from the MP_CAPABLE MPTCP Option
+type MPCapable struct {
+	BaseLayer
+	Version                uint8
+	A, B, C, D, E, F, G, H bool
+	SendKey                []byte
+	ReceivKey              []byte
+	DataLength             uint16
+	Checksum               uint16
+}
+
+// MPJoin contains the fields from the MP_JOIN MPTCP Option
+type MPJoin struct {
+	BaseLayer
+	Backup      bool
+	AddrID      uint8
+	ReceivToken uint32
+	SendRandNum uint32
+	SendHMAC    []byte
+}
+
+// Dss contains the fields from the DSS MPTCP Option
+type Dss struct {
+	BaseLayer
+	F, m, M, a, A bool
+	DataAck       []byte
+	DSN           []byte
+	SSN           uint32
+	DataLength    uint16
+	Checksum      uint16
+}
+
+// AddAddr contains the fields from the ADD_ADDR MPTCP Option
+type AddAddr struct {
+	BaseLayer
+	IPVer    uint8
+	E        bool
+	AddrID   uint8
+	Address  net.IP
+	Port     uint16
+	SendHMAC []byte
+}
+
+// RemAddr contains the fields from the REMOVE_ADDR MPTCP Option
+type RemAddr struct {
+	BaseLayer
+	AddrIDs []uint8
+}
+
+// MPPrio contains the fields from the MP_PRIO MPTCP Option
+type MPPrio struct {
+	BaseLayer
+	Backup bool
+	AddrID uint8
+}
+
+// MPFail contains the fields from the MP_FAIL MPTCP Option
+type MPFail struct {
+	BaseLayer
+	DSN uint64
+}
+
+// MPFClose contains the fields from the MP_FASTCLOSE MPTCP Option
+type MPFClose struct {
+	BaseLayer
+	ReceivKey []byte
+}
+
+// MPTcpRst contains the fields from the MP_TCPRST MPTCP Option
+type MPTcpRst struct {
+	BaseLayer
+	U, V, W, T bool
+	Reason     uint8
+}

--- a/layers/tcp_test.go
+++ b/layers/tcp_test.go
@@ -34,7 +34,15 @@ func TestTCPOptionKindString(t *testing.T) {
 			OptionLength: 10,
 			OptionData:   []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01},
 		},
-			"TCPOption(Timestamps:2/1 0x0000000200000001)"}}
+			"TCPOption(Timestamps:2/1 0x0000000200000001)"},
+		{&TCPOption{
+			OptionType:   TCPOptionKindMultipathTCP,
+			OptionLength: 4,
+			OptionMPTCPMpCapable: &MPCapable{
+				Version: 1,
+			},
+		},
+			"MPTCPOption(MP_CAPABLE Version 1)"}}
 
 	for _, tc := range testData {
 		if s := tc.o.String(); s != tc.s {
@@ -91,6 +99,56 @@ func TestPacketTCPOptionDecode(t *testing.T) {
 			OptionType:   TCPOptionKindMSS,
 			OptionLength: 4,
 			OptionData:   []byte{32, 00},
+		},
+		{
+			OptionType:   TCPOptionKindEndList,
+			OptionLength: 1,
+		},
+	}
+
+	if !reflect.DeepEqual(expected, tcp.Options) {
+		t.Errorf("expected options to be %#v, but got %#v", expected, tcp.Options)
+	}
+}
+
+// testPacketMPTCPOptionDecode is the packet:
+//
+//	16:17:26.239051 IP 192.168.0.1.12345 > 192.168.0.2.54321: Flags [S], seq 3735928559:3735928563, win 0, options [mss 8192,mpcapable,eol], length 8
+//		0x0000:  0000 0000 0001 0000  0000 0001 0800 4500  ..............E.
+//		0x0010:  0038 0000 0000 8006  0000 c0a8 0001 c0a8  .8..............
+//		0x0020:  0002 3039 d431 dead  beef 0000 0000 8002  ..09.1..........
+//		0x0030:  0000 0000 0000 0204  2000 1e04 0100 0000  ........ .......
+//		0x0040:  0000 5465 7374                            ..Test
+var testPacketMPTCPOptionDecode = []byte{
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00, 0x45, 0x00,
+	0x00, 0x38, 0x00, 0x00, 0x00, 0x00, 0x80, 0x06, 0x00, 0x00, 0xC0, 0xA8, 0x00, 0x01, 0xC0, 0xA8,
+	0x00, 0x02, 0x30, 0x39, 0xD4, 0x31, 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x80, 0x02,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x04, 0x20, 0x00, 0x1E, 0x04, 0x01, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x54, 0x65, 0x73, 0x74,
+}
+
+func TestPacketMPTCPOptionDecode(t *testing.T) {
+	p := gopacket.NewPacket(testPacketMPTCPOptionDecode, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode MPTCP packet:", p.ErrorLayer().Error())
+	}
+	tcp := p.Layer(LayerTypeTCP).(*TCP)
+	if tcp == nil {
+		t.Error("Expected TCP layer, but got none")
+	}
+
+	expected := []TCPOption{
+		{
+			OptionType:   TCPOptionKindMSS,
+			OptionLength: 4,
+			OptionData:   []byte{32, 00},
+		},
+		{
+			OptionType:   TCPOptionKindMultipathTCP,
+			OptionLength: 4,
+			OptionMPTCPMpCapable: &MPCapable{
+				Version: 1,
+			},
 		},
 		{
 			OptionType:   TCPOptionKindEndList,


### PR DESCRIPTION
- Support for decoding MPTCPv0 (RFC6824) and MPTCPv1 (RFC8684) packets
- Test for MPTCP

This replaces #63.

Work from @nkeukeleire, originally published on https://github.com/google/gopacket/pull/870.

On top of that, I did a rebase, fixed the conflicts, a few typos, ran the tests, nothing major.