### PR TITLE
Add support for bundled SCTP chunks

### DIFF
--- a/layers/decode_test.go
+++ b/layers/decode_test.go
@@ -657,9 +657,9 @@ func TestDecodeSCTPPackets(t *testing.T) {
 	wantLayers := [][]gopacket.LayerType{
 		[]gopacket.LayerType{LayerTypeSCTPInit},
 		[]gopacket.LayerType{LayerTypeSCTPInitAck},
-		[]gopacket.LayerType{LayerTypeSCTPCookieEcho, LayerTypeSCTPData, gopacket.LayerTypePayload},
+		[]gopacket.LayerType{LayerTypeSCTPCookieEcho, LayerTypeSCTPData},
 		[]gopacket.LayerType{LayerTypeSCTPCookieAck, LayerTypeSCTPSack},
-		[]gopacket.LayerType{LayerTypeSCTPData, gopacket.LayerTypePayload},
+		[]gopacket.LayerType{LayerTypeSCTPData},
 		[]gopacket.LayerType{LayerTypeSCTPSack},
 		[]gopacket.LayerType{LayerTypeSCTPShutdown},
 		[]gopacket.LayerType{LayerTypeSCTPShutdownAck},


### PR DESCRIPTION
Hello there,

I came across a problem while working with SCTP packets. According to the specification of SCTP there a packet might contain multiple chunks bundled together if the packet size allows it.

> [1.5.5. ](https://datatracker.ietf.org/doc/html/rfc9260#section-1.5.5)[Chunk Bundling](https://datatracker.ietf.org/doc/html/rfc9260#name-chunk-bundling)
>
>As described in [Section 3](https://datatracker.ietf.org/doc/html/rfc9260#sec_sctp_packet_format), the SCTP packet as delivered to the lower layer consists of a common header followed by one or more chunks. Each chunk contains either user data or SCTP control information. An SCTP implementation supporting bundling on the sender side might delay the sending of user messages to allow the corresponding DATA chunks to be bundled.

Sadly, `gopacket` does not yet support this while parsing or serializing. This is not a new issue and has already been discussed (https://github.com/google/gopacket/issues/347) and a working solution has been proposed (https://github.com/google/gopacket/pull/835)

Is there any change on getting this approved for a next release? And please let me know if there is anything I can do to speed up the process. 
