### PR TITLE
afpacket/pcapgo: fix htons in big endian systems

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/htons"
 )
 
 var pageSize = unix.Getpagesize()
@@ -163,7 +164,7 @@ func (h *TPacket) bindToInterface(ifaceName string) error {
 	}
 	h.ifIndex = ifIndex
 	s := &unix.SockaddrLinklayer{
-		Protocol: htons(uint16(unix.ETH_P_ALL)),
+		Protocol: htons.Htons(uint16(unix.ETH_P_ALL)),
 		Ifindex:  ifIndex,
 	}
 	return unix.Bind(h.fd, s)
@@ -254,7 +255,7 @@ func NewTPacket(opts ...interface{}) (h *TPacket, err error) {
 	if h.opts, err = parseOptions(opts...); err != nil {
 		return nil, err
 	}
-	fd, err := unix.Socket(unix.AF_PACKET, int(h.opts.socktype), int(htons(unix.ETH_P_ALL)))
+	fd, err := unix.Socket(unix.AF_PACKET, int(h.opts.socktype), int(htons.Htons(unix.ETH_P_ALL)))
 	if err != nil {
 		return nil, err
 	}

--- a/afpacket/sockopt_linux.go
+++ b/afpacket/sockopt_linux.go
@@ -50,10 +50,3 @@ func getsockopt(fd, level, name int, val unsafe.Pointer, vallen uintptr) error {
 
 	return nil
 }
-
-// htons converts a short (uint16) from host-to-network byte order.
-// Thanks to mikioh for this neat trick:
-// https://github.com/mikioh/-stdyng/blob/master/afpacket.go
-func htons(i uint16) uint16 {
-	return (i<<8)&0xff00 | i>>8
-}

--- a/htons/htons.go
+++ b/htons/htons.go
@@ -1,0 +1,12 @@
+package htons
+
+import "unsafe"
+
+// Htons converts x from host to network byte order.
+func Htons(x uint16) uint16 {
+	o := 1
+	if *(*byte)(unsafe.Pointer(&o)) == 0 {
+		return x
+	}
+	return x<<8 | x>>8
+}

--- a/htons/htons_test.go
+++ b/htons/htons_test.go
@@ -1,0 +1,32 @@
+package htons
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestHtons(t *testing.T) {
+	tt := []struct {
+		host, net uint16
+	}{
+		{0x0001, 0x0100},
+		{0xcafe, 0xfeca},
+		{0xbabe, 0xbeba},
+		{0x0000, 0x0000},
+		{0xffff, 0xffff},
+	}
+	x := 1
+	isBigEndian := *(*byte)(unsafe.Pointer(&x)) == 0
+	for _, v := range tt {
+		var want uint16
+		if isBigEndian {
+			want = v.host
+		} else {
+			want = v.net
+		}
+		x := Htons(v.host)
+		if x != want {
+			t.Errorf("isBig: %t htons(%04x) = <%04x> want <%04x>", isBigEndian, v.host, x, want)
+		}
+	}
+}

--- a/pcapgo/capture.go
+++ b/pcapgo/capture.go
@@ -22,14 +22,13 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/htons"
 )
 
 var hdrLen = unix.CmsgSpace(0)
 var auxLen = unix.CmsgSpace(int(unsafe.Sizeof(unix.TpacketAuxdata{})))
 var timensLen = unix.CmsgSpace(int(unsafe.Sizeof(unix.Timespec{})))
 var timeLen = unix.CmsgSpace(int(unsafe.Sizeof(unix.Timeval{})))
-
-func htons(data uint16) uint16 { return data<<8 | data>>8 }
 
 // EthernetHandle holds shared buffers and file descriptor of af_packet socket
 type EthernetHandle struct {
@@ -260,13 +259,13 @@ func NewEthernetHandle(ifname string) (*EthernetHandle, error) {
 		return nil, fmt.Errorf("couldn't query interface %s: %s", ifname, err)
 	}
 
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons.Htons(unix.ETH_P_ALL)))
 	if err != nil {
 		return nil, fmt.Errorf("couldn't open packet socket: %s", err)
 	}
 
 	addr := unix.SockaddrLinklayer{
-		Protocol: htons(unix.ETH_P_ALL),
+		Protocol: htons.Htons(unix.ETH_P_ALL),
 		Ifindex:  intf.Index,
 	}
 


### PR DESCRIPTION
Currently afpacket/pcapgo fails to receive any packet in big endian hosts because the interface index is never matched due the swap, regardless the host endianess

An alternative for unsafe would be add a dependency to Go maintained [x/sys/cpu](https://pkg.go.dev/golang.org/x/sys/cpu#IsBigEndian) and hope the tag list is maintained accordingly as architectures are added and removed, I found it too big of a dependency for a simple question, and that's cheap to compute at runtime, but it's up to you.
