### PR TITLE
afpacket: fix misuse of unsafe.Pointer

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -451,21 +451,18 @@ func (h *TPacket) getTPacketHeader() header {
 		if h.offset >= h.opts.framesPerBlock*h.opts.numBlocks {
 			h.offset = 0
 		}
-		position := uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset)
-		return (*v1header)(unsafe.Pointer(position))
+		return (*v1header)(unsafe.Pointer(uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset)))
 	case TPacketVersion2:
 		if h.offset >= h.opts.framesPerBlock*h.opts.numBlocks {
 			h.offset = 0
 		}
-		position := uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset)
-		return (*v2header)(unsafe.Pointer(position))
+		return (*v2header)(unsafe.Pointer(uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset)))
 	case TPacketVersion3:
 		// TPacket3 uses each block to return values, instead of each frame.  Hence we need to rotate when we hit #blocks, not #frames.
 		if h.offset >= h.opts.numBlocks {
 			h.offset = 0
 		}
-		position := uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset*h.opts.framesPerBlock)
-		h.v3 = initV3Wrapper(unsafe.Pointer(position))
+		h.v3 = initV3Wrapper(unsafe.Pointer(uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset*h.opts.framesPerBlock)))
 		return &h.v3
 	}
 	panic("handle tpacket version is invalid")

--- a/afpacket/header.go
+++ b/afpacket/header.go
@@ -257,12 +257,11 @@ func (w *v3wrapper) next() bool {
 		return false
 	}
 
-	next := uintptr(unsafe.Pointer(w.packet))
 	if w.packet.tp_next_offset != 0 {
-		next += uintptr(w.packet.tp_next_offset)
+		w.packet = (*tpacket3_hdr)(unsafe.Pointer((uintptr(unsafe.Pointer(w.packet)) + uintptr(w.packet.tp_next_offset))))
 	} else {
-		next += uintptr(tpAlign(int(w.packet.tp_snaplen) + int(w.packet.tp_mac)))
+		align := uintptr(tpAlign(int(w.packet.tp_snaplen) + int(w.packet.tp_mac)))
+		w.packet = (*tpacket3_hdr)(unsafe.Pointer(uintptr(unsafe.Pointer(w.packet)) + align))
 	}
-	w.packet = (*tpacket3_hdr)(unsafe.Pointer(next))
 	return true
 }


### PR DESCRIPTION
`go vet` warns about those lines, and I think code is indeed breaking rule 3 of unsafe.Pointer