### PR TITLE
layers: Remove trailing whitespace for Server Failure string

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -163,7 +163,7 @@ func (drc DNSResponseCode) String() string {
 	case DNSResponseCodeFormErr:
 		return "Format Error"
 	case DNSResponseCodeServFail:
-		return "Server Failure "
+		return "Server Failure"
 	case DNSResponseCodeNXDomain:
 		return "Non-Existent Domain"
 	case DNSResponseCodeNotImp:


### PR DESCRIPTION
We are using gopacket to parse messages in Inpektor Gadget using [trace dns gadget](https://www.inspektor-gadget.io/docs/v0.28.0/builtin-gadgets/trace/dns/). Users have an option to filter messages using `--filter rcode:"No Error"` so an extra space in a message can be an issue for the users! 

ref: https://github.com/google/gopacket/pull/1169