### PR TITLE
Fix mips cross compile

### DIFF
--- a/pcap/pcap_unix.go
+++ b/pcap/pcap_unix.go
@@ -131,13 +131,13 @@ int pcap_tstamp_type_name_to_val(const char* t) {
 		#define gopacket_time_secs_t u_int32_t
 		#define gopacket_time_usecs_t u_int32_t
 	#else
-    #ifdef __time64_t
-		  #define gopacket_time_secs_t __time64_t
-		  #define gopacket_time_usecs_t __suseconds64_t
-    #else
-		  #define gopacket_time_secs_t time_t
-		  #define gopacket_time_usecs_t suseconds_t
-    #endif
+		#ifdef __time64_t
+			#define gopacket_time_secs_t __time64_t
+			#define gopacket_time_usecs_t __suseconds64_t
+		#else
+			#define gopacket_time_secs_t time_t
+			#define gopacket_time_usecs_t suseconds_t
+		#endif
 	#endif
 #endif
 

--- a/pcap/pcap_unix.go
+++ b/pcap/pcap_unix.go
@@ -131,8 +131,13 @@ int pcap_tstamp_type_name_to_val(const char* t) {
 		#define gopacket_time_secs_t u_int32_t
 		#define gopacket_time_usecs_t u_int32_t
 	#else
-		#define gopacket_time_secs_t time_t
-		#define gopacket_time_usecs_t suseconds_t
+    #ifdef __time64_t
+		  #define gopacket_time_secs_t __time64_t
+		  #define gopacket_time_usecs_t __suseconds64_t
+    #else
+		  #define gopacket_time_secs_t time_t
+		  #define gopacket_time_usecs_t suseconds_t
+    #endif
 	#endif
 #endif
 


### PR DESCRIPTION
When cross compiling on `amd64-linux` by `CGO_ENABLED=1 GOOS=linux GOARCH=mips CC=mips-linux-gnu-gcc CGO_LDFLAGS="-L/tmp/libpcap-$PCAPV" go build`, this error would occur:
```
# github.com/gopacket/gopacket/pcap
../../../go/pkg/mod/github.com/gopacket/gopacket@v1.3.0/pcap/pcap_unix.go:355:18: cannot use _Ctype_gopacket_time_secs_t(ci.Timestamp.Unix()) (value of type _Ctype_gopacket_time_secs_t) as _Ctype___time64_t value in assignment
../../../go/pkg/mod/github.com/gopacket/gopacket@v1.3.0/pcap/pcap_unix.go:356:19: cannot use _Ctype_gopacket_time_usecs_t(ci.Timestamp.Nanosecond() / 1000) (value of type _Ctype_gopacket_time_usecs_t) as _Ctype___suseconds64_t value in assignment
```
After some investigation, the reason is that the C macro at the beginning of `pcap/pcap_unix.go` failed to define `gopacket_time_secs_t` and `gopacket_time_usecs_t` properly.

This commit fix it and it works well when cross compiling with per-compiled `libpcap`.  