### PR TITLE
Implemented slog.LogValuer on packet and certain layers

### DIFF
--- a/examples/packet-log/README.md
+++ b/examples/packet-log/README.md
@@ -1,0 +1,24 @@
+# packet-log
+
+This example shows how you can log packets using Go's built in [slog](https://pkg.go.dev/log/slog) logger.
+
+Logging using `slog` over printing the packet using `packet.String()` has two benefits:
+- Structured Logs over unstructured, see the [Go Blog for more details.](https://go.dev/blog/slog)
+- Performance, see the below benchmarks of calling `String` vs `LogValue` on a `Packet`.
+
+
+## Benchmarks
+```
+goos: darwin
+goarch: arm64
+pkg: github.com/gopacket/gopacket/examples/packet-log
+BenchmarkSlog_UDP
+BenchmarkSlog_UDP-10         	  788236	      1403 ns/op	    2928 B/op	      35 allocs/op
+BenchmarkRawString_UDP
+BenchmarkRawString_UDP-10    	   46135	     26229 ns/op	   23573 B/op	     657 allocs/op
+BenchmarkSlog_TCP
+BenchmarkSlog_TCP-10         	  484540	      2341 ns/op	    5952 B/op	      56 allocs/op
+BenchmarkRawString_TCP
+BenchmarkRawString_TCP-10    	   89091	     13429 ns/op	   10700 B/op	     352 allocs/op
+PASS
+```

--- a/examples/packet-log/main.go
+++ b/examples/packet-log/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/pcap"
+)
+
+func main() {
+	var iFace = flag.String("iface", "", "(required) interface to listen on")
+	var bpf = flag.String("bpf", "", "(optional) bpf to apply")
+	var format = flag.String("format", "json", "one of (text|json)")
+
+	flag.Parse()
+
+	logger := func(format string) *slog.Logger {
+		switch format {
+		case "text":
+			return slog.New(slog.NewTextHandler(os.Stdout, nil))
+		case "json":
+			return slog.New(slog.NewJSONHandler(os.Stdout, nil))
+		default:
+			fmt.Printf("Unknown format: %s\nSee flags\n", format)
+			flag.PrintDefaults()
+			os.Exit(1)
+			return nil
+		}
+	}(*format)
+
+	if *iFace == "" {
+		fmt.Println("Interface must be specified, see flags:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	logger.Info("Starting", slog.Group("config", slog.String("interface", *iFace)),
+		slog.String("format", *format),
+		slog.String("bpf", *bpf))
+
+	handle, err := pcap.OpenLive(*iFace, 1500, true, 30*time.Second)
+	if err != nil {
+		logger.Error("could not open interface", slog.String("interface", *iFace), slog.String("err", err.Error()))
+		os.Exit(1)
+	}
+	defer handle.Close()
+	if *bpf != "" {
+		if err := handle.SetBPFFilter(*bpf); err != nil {
+			logger.Error("could not set BPF filter", slog.String("err", err.Error()))
+			os.Exit(1)
+		}
+	}
+
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+	for packet := range packetSource.Packets() {
+		logger.Info("New Packet", slog.Any("packetData", packet))
+	}
+}

--- a/examples/packet-log/main_benchmark_test.go
+++ b/examples/packet-log/main_benchmark_test.go
@@ -1,0 +1,92 @@
+package main_test
+
+import (
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/pcap"
+)
+
+func BenchmarkSlog_UDP(b *testing.B) {
+	handle, err := pcap.OpenOffline("../../pcap/test_dns.pcap")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer handle.Close()
+
+	// Loop through packets in file
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+
+	packet, err := packetSource.NextPacket()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		packet.LogValue()
+	}
+}
+
+func BenchmarkRawString_UDP(b *testing.B) {
+	handle, err := pcap.OpenOffline("../../pcap/test_dns.pcap")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer handle.Close()
+
+	// Loop through packets in file
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+
+	packet, err := packetSource.NextPacket()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		packet.String()
+	}
+}
+
+func BenchmarkSlog_TCP(b *testing.B) {
+	handle, err := pcap.OpenOffline("../../pcap/test_ethernet.pcap")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer handle.Close()
+
+	// Loop through packets in file
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+
+	packet, err := packetSource.NextPacket()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		packet.LogValue()
+	}
+}
+
+func BenchmarkRawString_TCP(b *testing.B) {
+	handle, err := pcap.OpenOffline("../../pcap/test_ethernet.pcap")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer handle.Close()
+
+	// Loop through packets in file
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+
+	packet, err := packetSource.NextPacket()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		packet.String()
+	}
+}

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 
@@ -288,6 +289,29 @@ type DNS struct {
 	// name decoding on a single object via multiple DecodeFromBytes calls
 	// requiring constant allocation of small byte slices.
 	buffer []byte
+}
+
+func (d *DNS) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("ID", int(d.ID)),
+		slog.Bool("QR", d.QR),
+		slog.String("OPCode", d.OpCode.String()),
+		slog.Group("flags",
+			slog.Bool("authoritative answer", d.AA),
+			slog.Bool("truncated", d.TC),
+			slog.Bool("recursion desired", d.RD),
+			slog.Bool("recursion available", d.RA),
+			slog.Int("reserved", int(d.Z))),
+		slog.String("responseCode", d.ResponseCode.String()),
+		slog.Int("qdCount", int(d.QDCount)),
+		slog.Int("anCount", int(d.ANCount)),
+		slog.Int("nsCount", int(d.NSCount)),
+		slog.Int("arCount", int(d.ARCount)),
+		slog.Any("questions", d.Questions),
+		slog.Any("answers", d.Answers),
+		slog.Any("authorities", d.Authorities),
+		slog.Any("additionals", d.Additionals),
+	)
 }
 
 // LayerType returns gopacket.LayerTypeDNS.

--- a/layers/ethernet.go
+++ b/layers/ethernet.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 
 	"github.com/gopacket/gopacket"
@@ -30,6 +31,17 @@ type Ethernet struct {
 	// former is the case, we set EthernetType and Length stays 0.  In the latter
 	// case, we set Length and EthernetType = EthernetTypeLLC.
 	Length uint16
+}
+
+func (e *Ethernet) LogValue() slog.Value {
+	attrs := []slog.Attr{
+		slog.String("srcMac", e.SrcMAC.String()),
+		slog.String("dstMac", e.DstMAC.String()),
+		slog.String("type", e.EthernetType.String())}
+	if e.Length != 0 {
+		attrs = append(attrs, slog.Int("length", int(e.Length)))
+	}
+	return slog.GroupValue(attrs...)
 }
 
 // LayerType returns LayerTypeEthernet

--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 
@@ -96,6 +97,20 @@ func (ip *IPv4) getIPv4OptionSize() uint8 {
 		optionSize += 4 - (optionSize % 4)
 	}
 	return optionSize
+}
+
+func (ip *IPv4) LogValue() slog.Value {
+	attrs := []slog.Attr{
+		slog.Int("version", int(ip.Version)),
+		slog.Int("ihl", int(ip.IHL)),
+		slog.Int("tos", int(ip.TOS)),
+		slog.Int("length", int(ip.Length)),
+		slog.String("srcIP", ip.SrcIP.String()),
+		slog.String("dstIP", ip.DstIP.String())}
+	if len(ip.Padding) != 0 {
+		attrs = append(attrs, slog.Any("padding", ip.Padding))
+	}
+	return slog.GroupValue(attrs...)
 }
 
 // SerializeTo writes the serialized form of this layer into the

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 
 	"github.com/gopacket/gopacket"
@@ -40,6 +41,18 @@ type IPv6 struct {
 	HopByHop     *IPv6HopByHop
 	// hbh will be pointed to by HopByHop if that layer exists.
 	hbh IPv6HopByHop
+}
+
+func (ipv6 *IPv6) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("version", int(ipv6.Version)),
+		slog.Int("trafficClass", int(ipv6.TrafficClass)),
+		slog.Int("flowLabel", int(ipv6.FlowLabel)),
+		slog.Int("length", int(ipv6.Length)),
+		slog.String("nextHeader", ipv6.NextHeader.String()),
+		slog.Int("hopLimit", int(ipv6.HopLimit)),
+		slog.String("srcIP", ipv6.SrcIP.String()),
+		slog.String("dstIP", ipv6.DstIP.String()))
 }
 
 // LayerType returns LayerTypeIPv6

--- a/layers/udp.go
+++ b/layers/udp.go
@@ -10,6 +10,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
+	"log/slog"
 
 	"github.com/gopacket/gopacket"
 )
@@ -22,6 +23,14 @@ type UDP struct {
 	Checksum         uint16
 	sPort, dPort     []byte
 	tcpipchecksum
+}
+
+func (u *UDP) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("srcPort", int(u.SrcPort)),
+		slog.Int("dstPort", int(u.DstPort)),
+		slog.Int("length", int(u.Length)),
+		slog.Int("checksum", int(u.Checksum)))
 }
 
 // LayerType returns gopacket.LayerTypeUDP


### PR DESCRIPTION
Hello,

This PR implements [slog.LogValuer](https://pkg.go.dev/log/slog#LogValuer) on a `Packet`. This enables the logging of packets in a structured fashion. Please see `examples/packet-log/README.md` for more details on the benefits of this.

For now, I have only implemented `LogValuer` on the following layers:
- Ethernet
- TCP
- UDP
- DNS

This list of layers was picked to cover the bare minimum and most common forms of packets found in the tests. If this concept is approved and PR merged then more `Layers` can have it added in future PRs.