### PR TITLE
art: remove redundant type transformations and parentheses.

### DIFF
--- a/base.go
+++ b/base.go
@@ -43,19 +43,19 @@ type Payload []byte
 func (p Payload) LayerType() LayerType { return LayerTypePayload }
 
 // LayerContents returns the bytes making up this layer.
-func (p Payload) LayerContents() []byte { return []byte(p) }
+func (p Payload) LayerContents() []byte { return p }
 
 // LayerPayload returns the payload within this layer.
 func (p Payload) LayerPayload() []byte { return nil }
 
 // Payload returns this layer as bytes.
-func (p Payload) Payload() []byte { return []byte(p) }
+func (p Payload) Payload() []byte { return p }
 
 // String implements fmt.Stringer.
 func (p Payload) String() string { return fmt.Sprintf("%d byte(s)", len(p)) }
 
 // GoString implements fmt.GoStringer.
-func (p Payload) GoString() string { return LongBytesGoString([]byte(p)) }
+func (p Payload) GoString() string { return LongBytesGoString(p) }
 
 // CanDecode implements DecodingLayer.
 func (p Payload) CanDecode() LayerClass { return LayerTypePayload }
@@ -65,7 +65,7 @@ func (p Payload) NextLayerType() LayerType { return LayerTypeZero }
 
 // DecodeFromBytes implements DecodingLayer.
 func (p *Payload) DecodeFromBytes(data []byte, df DecodeFeedback) error {
-	*p = Payload(data)
+	*p = data
 	return nil
 }
 
@@ -100,13 +100,13 @@ type Fragment []byte
 func (p *Fragment) LayerType() LayerType { return LayerTypeFragment }
 
 // LayerContents implements Layer.
-func (p *Fragment) LayerContents() []byte { return []byte(*p) }
+func (p *Fragment) LayerContents() []byte { return *p }
 
 // LayerPayload implements Layer.
 func (p *Fragment) LayerPayload() []byte { return nil }
 
 // Payload returns this layer as a byte slice.
-func (p *Fragment) Payload() []byte { return []byte(*p) }
+func (p *Fragment) Payload() []byte { return *p }
 
 // String implements fmt.Stringer.
 func (p *Fragment) String() string { return fmt.Sprintf("%d byte(s)", len(*p)) }
@@ -119,7 +119,7 @@ func (p *Fragment) NextLayerType() LayerType { return LayerTypeZero }
 
 // DecodeFromBytes implements DecodingLayer.
 func (p *Fragment) DecodeFromBytes(data []byte, df DecodeFeedback) error {
-	*p = Fragment(data)
+	*p = data
 	return nil
 }
 

--- a/layerclass.go
+++ b/layerclass.go
@@ -53,13 +53,13 @@ func (s LayerClassSlice) LayerTypes() (all []LayerType) {
 // you implement your own LayerType and give it a high value, this WILL create
 // a very large slice.
 func NewLayerClassSlice(types []LayerType) LayerClassSlice {
-	var max LayerType
+	var maxType LayerType
 	for _, typ := range types {
-		if typ > max {
-			max = typ
+		if typ > maxType {
+			maxType = typ
 		}
 	}
-	t := make([]bool, int(max+1))
+	t := make([]bool, int(maxType+1))
 	for _, typ := range types {
 		t[typ] = true
 	}

--- a/layers/asf.go
+++ b/layers/asf.go
@@ -150,7 +150,7 @@ func (a *ASF) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 		return err
 	}
 	binary.BigEndian.PutUint32(bytes[:4], a.Enterprise)
-	bytes[4] = uint8(a.Type)
+	bytes[4] = a.Type
 	bytes[5] = a.Tag
 	bytes[6] = 0x00
 	if opts.FixLengths {

--- a/layers/bitfield.go
+++ b/layers/bitfield.go
@@ -9,7 +9,7 @@ type bitfield [1024]uint64
 
 // set sets bit i in bitfield b to 1.
 func (b *bitfield) set(i uint16) {
-	b[i>>6] |= (1 << (i & 0x3f))
+	b[i>>6] |= 1 << (i & 0x3f)
 }
 
 // has reports whether bit i is set to 1 in bitfield b.

--- a/layers/cdp.go
+++ b/layers/cdp.go
@@ -294,15 +294,15 @@ func decodeCiscoDiscoveryInfo(data []byte, p gopacket.PacketBuilder) error {
 				return err
 			}
 			val := CDPCapability(binary.BigEndian.Uint32(val.Value[0:4]))
-			info.Capabilities.L3Router = (val&CDPCapMaskRouter > 0)
-			info.Capabilities.TBBridge = (val&CDPCapMaskTBBridge > 0)
-			info.Capabilities.SPBridge = (val&CDPCapMaskSPBridge > 0)
-			info.Capabilities.L2Switch = (val&CDPCapMaskSwitch > 0)
-			info.Capabilities.IsHost = (val&CDPCapMaskHost > 0)
-			info.Capabilities.IGMPFilter = (val&CDPCapMaskIGMPFilter > 0)
-			info.Capabilities.L1Repeater = (val&CDPCapMaskRepeater > 0)
-			info.Capabilities.IsPhone = (val&CDPCapMaskPhone > 0)
-			info.Capabilities.RemotelyManaged = (val&CDPCapMaskRemote > 0)
+			info.Capabilities.L3Router = val&CDPCapMaskRouter > 0
+			info.Capabilities.TBBridge = val&CDPCapMaskTBBridge > 0
+			info.Capabilities.SPBridge = val&CDPCapMaskSPBridge > 0
+			info.Capabilities.L2Switch = val&CDPCapMaskSwitch > 0
+			info.Capabilities.IsHost = val&CDPCapMaskHost > 0
+			info.Capabilities.IGMPFilter = val&CDPCapMaskIGMPFilter > 0
+			info.Capabilities.L1Repeater = val&CDPCapMaskRepeater > 0
+			info.Capabilities.IsPhone = val&CDPCapMaskPhone > 0
+			info.Capabilities.RemotelyManaged = val&CDPCapMaskRemote > 0
 		case CDPTLVVersion:
 			info.Version = string(val.Value)
 		case CDPTLVPlatform:
@@ -347,18 +347,18 @@ func decodeCiscoDiscoveryInfo(data []byte, p gopacket.PacketBuilder) error {
 			if err = checkCDPTLVLen(val, 1); err != nil {
 				return err
 			}
-			info.FullDuplex = (val.Value[0] == 1)
+			info.FullDuplex = val.Value[0] == 1
 		case CDPTLVVLANReply:
 			if err = checkCDPTLVLen(val, 3); err != nil {
 				return err
 			}
-			info.VLANReply.ID = uint8(val.Value[0])
+			info.VLANReply.ID = val.Value[0]
 			info.VLANReply.VLAN = binary.BigEndian.Uint16(val.Value[1:3])
 		case CDPTLVVLANQuery:
 			if err = checkCDPTLVLen(val, 3); err != nil {
 				return err
 			}
-			info.VLANQuery.ID = uint8(val.Value[0])
+			info.VLANQuery.ID = val.Value[0]
 			info.VLANQuery.VLAN = binary.BigEndian.Uint16(val.Value[1:3])
 		case CDPTLVPower:
 			if err = checkCDPTLVLen(val, 2); err != nil {
@@ -374,12 +374,12 @@ func decodeCiscoDiscoveryInfo(data []byte, p gopacket.PacketBuilder) error {
 			if err = checkCDPTLVLen(val, 1); err != nil {
 				return err
 			}
-			info.ExtendedTrust = uint8(val.Value[0])
+			info.ExtendedTrust = val.Value[0]
 		case CDPTLVUntrustedCOS:
 			if err = checkCDPTLVLen(val, 1); err != nil {
 				return err
 			}
-			info.UntrustedCOS = uint8(val.Value[0])
+			info.UntrustedCOS = val.Value[0]
 		case CDPTLVSysName:
 			info.SysName = string(val.Value)
 		case CDPTLVSysOID:
@@ -396,7 +396,7 @@ func decodeCiscoDiscoveryInfo(data []byte, p gopacket.PacketBuilder) error {
 			if err = checkCDPTLVLen(val, 2); err != nil {
 				return err
 			}
-			info.Location.Type = uint8(val.Value[0])
+			info.Location.Type = val.Value[0]
 			info.Location.Location = string(val.Value[1:])
 
 			//		case CDPTLVLExternalPortID:
@@ -474,10 +474,10 @@ func decodeCiscoDiscoveryInfo(data []byte, p gopacket.PacketBuilder) error {
 				return err
 			}
 			v := val.Value[0]
-			info.SparePairPoe.PSEFourWire = (v&CDPPoEFourWire > 0)
-			info.SparePairPoe.PDArchShared = (v&CDPPoEPDArch > 0)
-			info.SparePairPoe.PDRequestOn = (v&CDPPoEPDRequest > 0)
-			info.SparePairPoe.PSEOn = (v&CDPPoEPSE > 0)
+			info.SparePairPoe.PSEFourWire = v&CDPPoEFourWire > 0
+			info.SparePairPoe.PDArchShared = v&CDPPoEPDArch > 0
+			info.SparePairPoe.PDRequestOn = v&CDPPoEPDRequest > 0
+			info.SparePairPoe.PSEOn = v&CDPPoEPSE > 0
 		default:
 			info.Unknown = append(info.Unknown, val)
 		}
@@ -535,7 +535,7 @@ func decodeAddresses(v []byte) (addresses []net.IP, err error) {
 		if protocol == CDPAddressTypeIPV4 && addrlen == 4 {
 			addresses = append(addresses, net.IPv4(ab[0], ab[1], ab[2], ab[3]))
 		} else if protocol == CDPAddressTypeIPV6 && addrlen == 16 {
-			addresses = append(addresses, net.IP(ab))
+			addresses = append(addresses, ab)
 		} else {
 			// only handle IPV4 & IPV6 for now
 		}

--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -136,11 +136,11 @@ func (d *DHCPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 	d.Xid = binary.BigEndian.Uint32(data[4:8])
 	d.Secs = binary.BigEndian.Uint16(data[8:10])
 	d.Flags = binary.BigEndian.Uint16(data[10:12])
-	d.ClientIP = net.IP(data[12:16])
-	d.YourClientIP = net.IP(data[16:20])
-	d.NextServerIP = net.IP(data[20:24])
-	d.RelayAgentIP = net.IP(data[24:28])
-	d.ClientHWAddr = net.HardwareAddr(data[28 : 28+d.HardwareLen])
+	d.ClientIP = data[12:16]
+	d.YourClientIP = data[16:20]
+	d.NextServerIP = data[20:24]
+	d.RelayAgentIP = data[24:28]
+	d.ClientHWAddr = data[28 : 28+d.HardwareLen]
 	d.ServerName = data[44:108]
 	d.File = data[108:236]
 	if binary.BigEndian.Uint32(data[236:240]) != DHCPMagic {

--- a/layers/lldp.go
+++ b/layers/lldp.go
@@ -951,8 +951,8 @@ func (l *LinkLayerDiscoveryInfo) Decode8021() (info LLDPInfo8021, err error) {
 			if err = checkLLDPOrgSpecificLen(o, 5); err != nil {
 				return
 			}
-			sup := (o.Info[0]&LLDPAggregationCapability > 0)
-			en := (o.Info[0]&LLDPAggregationStatus > 0)
+			sup := o.Info[0]&LLDPAggregationCapability > 0
+			en := o.Info[0]&LLDPAggregationStatus > 0
 			info.LinkAggregation = LLDPLinkAggregation{sup, en, binary.BigEndian.Uint32(o.Info[1:5])}
 		}
 	}
@@ -969,8 +969,8 @@ func (l *LinkLayerDiscoveryInfo) Decode8023() (info LLDPInfo8023, err error) {
 			if err = checkLLDPOrgSpecificLen(o, 5); err != nil {
 				return
 			}
-			sup := (o.Info[0]&LLDPMACPHYCapability > 0)
-			en := (o.Info[0]&LLDPMACPHYStatus > 0)
+			sup := o.Info[0]&LLDPMACPHYCapability > 0
+			en := o.Info[0]&LLDPMACPHYStatus > 0
 			ca := binary.BigEndian.Uint16(o.Info[1:3])
 			mau := binary.BigEndian.Uint16(o.Info[3:5])
 			info.MACPHYConfigStatus = LLDPMACPHYConfigStatus{sup, en, ca, mau}
@@ -978,12 +978,12 @@ func (l *LinkLayerDiscoveryInfo) Decode8023() (info LLDPInfo8023, err error) {
 			if err = checkLLDPOrgSpecificLen(o, 3); err != nil {
 				return
 			}
-			info.PowerViaMDI.PortClassPSE = (o.Info[0]&LLDPMDIPowerPortClass > 0)
-			info.PowerViaMDI.PSESupported = (o.Info[0]&LLDPMDIPowerCapability > 0)
-			info.PowerViaMDI.PSEEnabled = (o.Info[0]&LLDPMDIPowerStatus > 0)
-			info.PowerViaMDI.PSEPairsAbility = (o.Info[0]&LLDPMDIPowerPairsAbility > 0)
-			info.PowerViaMDI.PSEPowerPair = uint8(o.Info[1])
-			info.PowerViaMDI.PSEClass = uint8(o.Info[2])
+			info.PowerViaMDI.PortClassPSE = o.Info[0]&LLDPMDIPowerPortClass > 0
+			info.PowerViaMDI.PSESupported = o.Info[0]&LLDPMDIPowerCapability > 0
+			info.PowerViaMDI.PSEEnabled = o.Info[0]&LLDPMDIPowerStatus > 0
+			info.PowerViaMDI.PSEPairsAbility = o.Info[0]&LLDPMDIPowerPairsAbility > 0
+			info.PowerViaMDI.PSEPowerPair = o.Info[1]
+			info.PowerViaMDI.PSEClass = o.Info[2]
 			if len(o.Info) >= 7 {
 				info.PowerViaMDI.Type = LLDPPowerType((o.Info[3] & 0xc0) >> 6)
 				info.PowerViaMDI.Source = LLDPPowerSource((o.Info[3] & 0x30) >> 4)
@@ -1060,7 +1060,7 @@ func (l *LinkLayerDiscoveryInfo) DecodeMedia() (info LLDPInfoMedia, err error) {
 			info.NetworkPolicy.VLANId = (b & 0x1ffe) >> 1
 			b = binary.BigEndian.Uint16(o.Info[2:4])
 			info.NetworkPolicy.L2Priority = (b & 0x01c0) >> 6
-			info.NetworkPolicy.DSCPValue = uint8(o.Info[3] & 0x3f)
+			info.NetworkPolicy.DSCPValue = o.Info[3] & 0x3f
 		case LLDPMediaTypeLocation:
 			if err = checkLLDPOrgSpecificLen(o, 1); err != nil {
 				return
@@ -1078,12 +1078,12 @@ func (l *LinkLayerDiscoveryInfo) DecodeMedia() (info LLDPInfoMedia, err error) {
 				info.Location.Coordinate.LongitudeResolution = uint8(o.Info[5]&0xfc) >> 2
 				b = binary.BigEndian.Uint64(o.Info[5:13])
 				info.Location.Coordinate.Longitude = (b & 0x03ffffffff000000) >> 24
-				info.Location.Coordinate.AltitudeType = uint8((o.Info[10] & 0x30) >> 4)
+				info.Location.Coordinate.AltitudeType = (o.Info[10] & 0x30) >> 4
 				b1 := binary.BigEndian.Uint16(o.Info[10:12])
 				info.Location.Coordinate.AltitudeResolution = (b1 & 0xfc0) >> 6
 				b2 := binary.BigEndian.Uint32(o.Info[11:15])
 				info.Location.Coordinate.Altitude = b2 & 0x3fffffff
-				info.Location.Coordinate.Datum = uint8(o.Info[15])
+				info.Location.Coordinate.Datum = o.Info[15]
 			case LLDPLocationFormatAddress:
 				if err = checkLLDPOrgSpecificLen(o, 3); err != nil {
 					return
@@ -1216,17 +1216,17 @@ func (c *LinkLayerDiscoveryInfo) LayerType() gopacket.LayerType {
 }
 
 func getCapabilities(v uint16) (c LLDPCapabilities) {
-	c.Other = (v&LLDPCapsOther > 0)
-	c.Repeater = (v&LLDPCapsRepeater > 0)
-	c.Bridge = (v&LLDPCapsBridge > 0)
-	c.WLANAP = (v&LLDPCapsWLANAP > 0)
-	c.Router = (v&LLDPCapsRouter > 0)
-	c.Phone = (v&LLDPCapsPhone > 0)
-	c.DocSis = (v&LLDPCapsDocSis > 0)
-	c.StationOnly = (v&LLDPCapsStationOnly > 0)
-	c.CVLAN = (v&LLDPCapsCVLAN > 0)
-	c.SVLAN = (v&LLDPCapsSVLAN > 0)
-	c.TMPR = (v&LLDPCapsTmpr > 0)
+	c.Other = v&LLDPCapsOther > 0
+	c.Repeater = v&LLDPCapsRepeater > 0
+	c.Bridge = v&LLDPCapsBridge > 0
+	c.WLANAP = v&LLDPCapsWLANAP > 0
+	c.Router = v&LLDPCapsRouter > 0
+	c.Phone = v&LLDPCapsPhone > 0
+	c.DocSis = v&LLDPCapsDocSis > 0
+	c.StationOnly = v&LLDPCapsStationOnly > 0
+	c.CVLAN = v&LLDPCapsCVLAN > 0
+	c.SVLAN = v&LLDPCapsSVLAN > 0
+	c.TMPR = v&LLDPCapsTmpr > 0
 	return
 }
 

--- a/layers/ndp.go
+++ b/layers/ndp.go
@@ -234,7 +234,7 @@ func decodeNortelDiscovery(data []byte, p gopacket.PacketBuilder) error {
 	c.Chassis = NDPChassisType(data[7])
 	c.Backplane = NDPBackplaneType(data[8])
 	c.State = NDPState(data[9])
-	c.NumLinks = uint8(data[10])
+	c.NumLinks = data[10]
 	p.AddLayer(c)
 	return nil
 }

--- a/layers/ntp.go
+++ b/layers/ntp.go
@@ -313,7 +313,7 @@ func (d *NTP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	//    Contents is supposed to contain the bytes of the data at this level.
 	//    Payload is supposed to contain the payload of this level.
 	// Here we set the baselayer to be the bytes of the NTP record.
-	d.BaseLayer = BaseLayer{Contents: data[:len(data)]}
+	d.BaseLayer = BaseLayer{Contents: data[:]}
 
 	// Extract the fields from the block of bytes.
 	// To make sense of this, refer to the packet diagram
@@ -360,7 +360,7 @@ func (d *NTP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 	h |= (uint8(d.LeapIndicator) << 6) & 0xC0
 	h |= (uint8(d.Version) << 3) & 0x38
 	h |= (uint8(d.Mode)) & 0x07
-	data[0] = byte(h)
+	data[0] = h
 	data[1] = byte(d.Stratum)
 	data[2] = byte(d.Poll)
 	data[3] = byte(d.Precision)

--- a/layers/prism.go
+++ b/layers/prism.go
@@ -116,7 +116,7 @@ func (m *PrismHeader) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) e
 	m.Code = binary.LittleEndian.Uint16(data[0:4])
 	m.Length = binary.LittleEndian.Uint16(data[4:8])
 	m.DeviceName = string(data[8:24])
-	m.BaseLayer = BaseLayer{Contents: data[:m.Length], Payload: data[m.Length:len(data)]}
+	m.BaseLayer = BaseLayer{Contents: data[:m.Length], Payload: data[m.Length:]}
 
 	switch m.Code {
 	case PrismType1MessageCode:

--- a/layers/radiotap.go
+++ b/layers/radiotap.go
@@ -21,7 +21,7 @@ import (
 // on the offset, returning the number of bytes we need to skip to
 // align to the offset (width).
 func align(offset uint16, width uint16) uint16 {
-	return ((((offset) + ((width) - 1)) & (^((width) - 1))) - offset)
+	return (((offset) + ((width) - 1)) & (^((width) - 1))) - offset
 }
 
 type RadioTapPresent uint32
@@ -250,27 +250,27 @@ func (r RadioTapFlags) ShortGI() bool {
 // String provides a human readable string for RadioTapFlags.
 // This string is possibly subject to change over time; if you're storing this
 // persistently, you should probably store the RadioTapFlags value, not its string.
-func (a RadioTapFlags) String() string {
+func (r RadioTapFlags) String() string {
 	var out bytes.Buffer
-	if a.CFP() {
+	if r.CFP() {
 		out.WriteString("CFP,")
 	}
-	if a.ShortPreamble() {
+	if r.ShortPreamble() {
 		out.WriteString("SHORT-PREAMBLE,")
 	}
-	if a.WEP() {
+	if r.WEP() {
 		out.WriteString("WEP,")
 	}
-	if a.Frag() {
+	if r.Frag() {
 		out.WriteString("FRAG,")
 	}
-	if a.FCS() {
+	if r.FCS() {
 		out.WriteString("FCS,")
 	}
-	if a.Datapad() {
+	if r.Datapad() {
 		out.WriteString("DATAPAD,")
 	}
-	if a.ShortGI() {
+	if r.ShortGI() {
 		out.WriteString("SHORT-GI,")
 	}
 
@@ -318,23 +318,23 @@ const (
 	RadioTapTxFlagsNoACK
 )
 
-func (self RadioTapTxFlags) Fail() bool  { return self&RadioTapTxFlagsFail != 0 }
-func (self RadioTapTxFlags) CTS() bool   { return self&RadioTapTxFlagsCTS != 0 }
-func (self RadioTapTxFlags) RTS() bool   { return self&RadioTapTxFlagsRTS != 0 }
-func (self RadioTapTxFlags) NoACK() bool { return self&RadioTapTxFlagsNoACK != 0 }
+func (r RadioTapTxFlags) Fail() bool  { return r&RadioTapTxFlagsFail != 0 }
+func (r RadioTapTxFlags) CTS() bool   { return r&RadioTapTxFlagsCTS != 0 }
+func (r RadioTapTxFlags) RTS() bool   { return r&RadioTapTxFlagsRTS != 0 }
+func (r RadioTapTxFlags) NoACK() bool { return r&RadioTapTxFlagsNoACK != 0 }
 
-func (self RadioTapTxFlags) String() string {
+func (r RadioTapTxFlags) String() string {
 	var tokens []string
-	if self.Fail() {
+	if r.Fail() {
 		tokens = append(tokens, "Fail")
 	}
-	if self.CTS() {
+	if r.CTS() {
 		tokens = append(tokens, "CTS")
 	}
-	if self.RTS() {
+	if r.RTS() {
 		tokens = append(tokens, "RTS")
 	}
-	if self.NoACK() {
+	if r.NoACK() {
 		tokens = append(tokens, "NoACK")
 	}
 	return strings.Join(tokens, ",")
@@ -415,14 +415,14 @@ const (
 	RadioTapMCSKnownNESS1
 )
 
-func (self RadioTapMCSKnown) Bandwidth() bool     { return self&RadioTapMCSKnownBandwidth != 0 }
-func (self RadioTapMCSKnown) MCSIndex() bool      { return self&RadioTapMCSKnownMCSIndex != 0 }
-func (self RadioTapMCSKnown) GuardInterval() bool { return self&RadioTapMCSKnownGuardInterval != 0 }
-func (self RadioTapMCSKnown) HTFormat() bool      { return self&RadioTapMCSKnownHTFormat != 0 }
-func (self RadioTapMCSKnown) FECType() bool       { return self&RadioTapMCSKnownFECType != 0 }
-func (self RadioTapMCSKnown) STBC() bool          { return self&RadioTapMCSKnownSTBC != 0 }
-func (self RadioTapMCSKnown) NESS() bool          { return self&RadioTapMCSKnownNESS != 0 }
-func (self RadioTapMCSKnown) NESS1() bool         { return self&RadioTapMCSKnownNESS1 != 0 }
+func (r RadioTapMCSKnown) Bandwidth() bool     { return r&RadioTapMCSKnownBandwidth != 0 }
+func (r RadioTapMCSKnown) MCSIndex() bool      { return r&RadioTapMCSKnownMCSIndex != 0 }
+func (r RadioTapMCSKnown) GuardInterval() bool { return r&RadioTapMCSKnownGuardInterval != 0 }
+func (r RadioTapMCSKnown) HTFormat() bool      { return r&RadioTapMCSKnownHTFormat != 0 }
+func (r RadioTapMCSKnown) FECType() bool       { return r&RadioTapMCSKnownFECType != 0 }
+func (r RadioTapMCSKnown) STBC() bool          { return r&RadioTapMCSKnownSTBC != 0 }
+func (r RadioTapMCSKnown) NESS() bool          { return r&RadioTapMCSKnownNESS != 0 }
+func (r RadioTapMCSKnown) NESS1() bool         { return r&RadioTapMCSKnownNESS1 != 0 }
 
 type RadioTapMCSFlags uint8
 
@@ -435,16 +435,16 @@ const (
 	RadioTapMCSFlagsNESS0                          = 0x80
 )
 
-func (self RadioTapMCSFlags) Bandwidth() int {
-	return int(self & RadioTapMCSFlagsBandwidthMask)
+func (r RadioTapMCSFlags) Bandwidth() int {
+	return int(r & RadioTapMCSFlagsBandwidthMask)
 }
-func (self RadioTapMCSFlags) ShortGI() bool    { return self&RadioTapMCSFlagsShortGI != 0 }
-func (self RadioTapMCSFlags) Greenfield() bool { return self&RadioTapMCSFlagsGreenfield != 0 }
-func (self RadioTapMCSFlags) FECLDPC() bool    { return self&RadioTapMCSFlagsFECLDPC != 0 }
-func (self RadioTapMCSFlags) STBC() int {
-	return int(self&RadioTapMCSFlagsSTBCMask) >> 5
+func (r RadioTapMCSFlags) ShortGI() bool    { return r&RadioTapMCSFlagsShortGI != 0 }
+func (r RadioTapMCSFlags) Greenfield() bool { return r&RadioTapMCSFlagsGreenfield != 0 }
+func (r RadioTapMCSFlags) FECLDPC() bool    { return r&RadioTapMCSFlagsFECLDPC != 0 }
+func (r RadioTapMCSFlags) STBC() int {
+	return int(r&RadioTapMCSFlagsSTBCMask) >> 5
 }
-func (self RadioTapMCSFlags) NESS0() bool { return self&RadioTapMCSFlagsNESS0 != 0 }
+func (r RadioTapMCSFlags) NESS0() bool { return r&RadioTapMCSFlagsNESS0 != 0 }
 
 type RadioTapAMPDUStatus struct {
 	Reference uint32
@@ -482,15 +482,15 @@ const (
 	RadioTapAMPDUDelimCRCKnown
 )
 
-func (self RadioTapAMPDUStatusFlags) ReportZerolen() bool {
-	return self&RadioTapAMPDUStatusFlagsReportZerolen != 0
+func (r RadioTapAMPDUStatusFlags) ReportZerolen() bool {
+	return r&RadioTapAMPDUStatusFlagsReportZerolen != 0
 }
-func (self RadioTapAMPDUStatusFlags) IsZerolen() bool   { return self&RadioTapAMPDUIsZerolen != 0 }
-func (self RadioTapAMPDUStatusFlags) LastKnown() bool   { return self&RadioTapAMPDULastKnown != 0 }
-func (self RadioTapAMPDUStatusFlags) IsLast() bool      { return self&RadioTapAMPDUIsLast != 0 }
-func (self RadioTapAMPDUStatusFlags) DelimCRCErr() bool { return self&RadioTapAMPDUDelimCRCErr != 0 }
-func (self RadioTapAMPDUStatusFlags) DelimCRCKnown() bool {
-	return self&RadioTapAMPDUDelimCRCKnown != 0
+func (r RadioTapAMPDUStatusFlags) IsZerolen() bool   { return r&RadioTapAMPDUIsZerolen != 0 }
+func (r RadioTapAMPDUStatusFlags) LastKnown() bool   { return r&RadioTapAMPDULastKnown != 0 }
+func (r RadioTapAMPDUStatusFlags) IsLast() bool      { return r&RadioTapAMPDUIsLast != 0 }
+func (r RadioTapAMPDUStatusFlags) DelimCRCErr() bool { return r&RadioTapAMPDUDelimCRCErr != 0 }
+func (r RadioTapAMPDUStatusFlags) DelimCRCKnown() bool {
+	return r&RadioTapAMPDUDelimCRCKnown != 0
 }
 
 type RadioTapVHT struct {
@@ -844,72 +844,72 @@ const (
 	RadiotapHEData1DopplerKnown                RadiotapHEData1 = 0x8000
 )
 
-func (self RadiotapHEData1) HE_PPDUFormat() RadiotapHePpduFormat {
-	return RadiotapHePpduFormat(self & 0x0003)
+func (r RadiotapHEData1) HE_PPDUFormat() RadiotapHePpduFormat {
+	return RadiotapHePpduFormat(r & 0x0003)
 }
 
-func (self RadiotapHEData1) BSSColorKnown() bool {
-	return self&RadiotapHEData1BSSColorKnown != 0
+func (r RadiotapHEData1) BSSColorKnown() bool {
+	return r&RadiotapHEData1BSSColorKnown != 0
 }
 
-func (self RadiotapHEData1) BeamChangeKnown() bool {
-	return self&RadiotapHEData1BeamChangeKnown != 0
+func (r RadiotapHEData1) BeamChangeKnown() bool {
+	return r&RadiotapHEData1BeamChangeKnown != 0
 }
 
-func (self RadiotapHEData1) ULDLKnown() bool {
-	return self&RadiotapHEData1ULDLKnown != 0
+func (r RadiotapHEData1) ULDLKnown() bool {
+	return r&RadiotapHEData1ULDLKnown != 0
 }
 
-func (self RadiotapHEData1) DataMCSKnown() bool {
-	return self&RadiotapHEData1DataMCSKnown != 0
+func (r RadiotapHEData1) DataMCSKnown() bool {
+	return r&RadiotapHEData1DataMCSKnown != 0
 }
 
-func (self RadiotapHEData1) DataDCMKnown() bool {
-	return self&RadiotapHEData1DataDCMKnown != 0
+func (r RadiotapHEData1) DataDCMKnown() bool {
+	return r&RadiotapHEData1DataDCMKnown != 0
 }
 
-func (self RadiotapHEData1) CodingKnown() bool {
-	return self&RadiotapHEData1CodingKnown != 0
+func (r RadiotapHEData1) CodingKnown() bool {
+	return r&RadiotapHEData1CodingKnown != 0
 }
 
-func (self RadiotapHEData1) LDPCExtraSymbolSegmentKnown() bool {
-	return self&RadiotapHEData1LDPCExtraSymbolSegmentKnown != 0
+func (r RadiotapHEData1) LDPCExtraSymbolSegmentKnown() bool {
+	return r&RadiotapHEData1LDPCExtraSymbolSegmentKnown != 0
 }
 
-func (self RadiotapHEData1) STBCKnown() bool {
-	return self&RadiotapHEData1STBCKnown != 0
+func (r RadiotapHEData1) STBCKnown() bool {
+	return r&RadiotapHEData1STBCKnown != 0
 }
 
-func (self RadiotapHEData1) SpatialReuseKnown() bool {
-	return self&RadiotapHEData1SpatialReuseKnown != 0
+func (r RadiotapHEData1) SpatialReuseKnown() bool {
+	return r&RadiotapHEData1SpatialReuseKnown != 0
 }
 
-func (self RadiotapHEData1) SpatialReuse1Known() bool {
-	return self&RadiotapHEData1SpatialReuse1Known != 0
+func (r RadiotapHEData1) SpatialReuse1Known() bool {
+	return r&RadiotapHEData1SpatialReuse1Known != 0
 }
 
-func (self RadiotapHEData1) SpatialReuse2Known() bool {
-	return self&RadiotapHEData1SpatialReuse2Known != 0
+func (r RadiotapHEData1) SpatialReuse2Known() bool {
+	return r&RadiotapHEData1SpatialReuse2Known != 0
 }
 
-func (self RadiotapHEData1) StaIDKnown() bool {
-	return self&RadiotapHEData1StaIDKnown != 0
+func (r RadiotapHEData1) StaIDKnown() bool {
+	return r&RadiotapHEData1StaIDKnown != 0
 }
 
-func (self RadiotapHEData1) SpatialReuse3Known() bool {
-	return self&RadiotapHEData1SpatialReuse3Known != 0
+func (r RadiotapHEData1) SpatialReuse3Known() bool {
+	return r&RadiotapHEData1SpatialReuse3Known != 0
 }
 
-func (self RadiotapHEData1) SpatialReuse4Known() bool {
-	return self&RadiotapHEData1SpatialReuse4Known != 0
+func (r RadiotapHEData1) SpatialReuse4Known() bool {
+	return r&RadiotapHEData1SpatialReuse4Known != 0
 }
 
-func (self RadiotapHEData1) DataBWRUAllocationKnown() bool {
-	return self&RadiotapHEData1DataBWRUAllocationKnown != 0
+func (r RadiotapHEData1) DataBWRUAllocationKnown() bool {
+	return r&RadiotapHEData1DataBWRUAllocationKnown != 0
 }
 
-func (self RadiotapHEData1) DopplerKnown() bool {
-	return self&RadiotapHEData1DopplerKnown != 0
+func (r RadiotapHEData1) DopplerKnown() bool {
+	return r&RadiotapHEData1DopplerKnown != 0
 }
 
 type RadiotapHePpduFormat uint8
@@ -921,8 +921,8 @@ const (
 	RadiotapHePpduFormatHE_TRIG
 )
 
-func (self RadiotapHePpduFormat) String() string {
-	switch self {
+func (r RadiotapHePpduFormat) String() string {
+	switch r {
 	case RadiotapHePpduFormatHE_SU:
 		return "HE SU"
 	case RadiotapHePpduFormatHE_EXT_SU:
@@ -932,7 +932,7 @@ func (self RadiotapHePpduFormat) String() string {
 	case RadiotapHePpduFormatHE_TRIG:
 		return "HE TRIG"
 	}
-	return fmt.Sprintf("HE Unknown(%d)", self)
+	return fmt.Sprintf("HE Unknown(%d)", r)
 }
 
 type RadiotapHEData2 uint16
@@ -951,48 +951,48 @@ const (
 	RadiotapHEData2PriSec80MHz              RadiotapHEData2 = 0x8000
 )
 
-func (self RadiotapHEData2) PriSec80MHzKnown() bool {
-	return self&RadiotapHEData2PriSec80MHzKnown != 0
+func (r RadiotapHEData2) PriSec80MHzKnown() bool {
+	return r&RadiotapHEData2PriSec80MHzKnown != 0
 }
 
-func (self RadiotapHEData2) GIKnown() bool {
-	return self&RadiotapHEData2GIKnown != 0
+func (r RadiotapHEData2) GIKnown() bool {
+	return r&RadiotapHEData2GIKnown != 0
 }
 
-func (self RadiotapHEData2) NumLTFKnown() bool {
-	return self&RadiotapHEData2NumLTFKnown != 0
+func (r RadiotapHEData2) NumLTFKnown() bool {
+	return r&RadiotapHEData2NumLTFKnown != 0
 }
 
-func (self RadiotapHEData2) PreFECPaddingFactorKnown() bool {
-	return self&RadiotapHEData2PreFECPaddingFactorKnown != 0
+func (r RadiotapHEData2) PreFECPaddingFactorKnown() bool {
+	return r&RadiotapHEData2PreFECPaddingFactorKnown != 0
 }
 
-func (self RadiotapHEData2) TxBFKnown() bool {
-	return self&RadiotapHEData2TxBFKnown != 0
+func (r RadiotapHEData2) TxBFKnown() bool {
+	return r&RadiotapHEData2TxBFKnown != 0
 }
 
-func (self RadiotapHEData2) PEDisambiguityKnown() bool {
-	return self&RadiotapHEData2PEDisambiguityKnown != 0
+func (r RadiotapHEData2) PEDisambiguityKnown() bool {
+	return r&RadiotapHEData2PEDisambiguityKnown != 0
 }
 
-func (self RadiotapHEData2) TXOPKnown() bool {
-	return self&RadiotapHEData2TXOPKnown != 0
+func (r RadiotapHEData2) TXOPKnown() bool {
+	return r&RadiotapHEData2TXOPKnown != 0
 }
 
-func (self RadiotapHEData2) MidamblePeriodicityKnown() bool {
-	return self&RadiotapHEData2MidamblePeriodicityKnown != 0
+func (r RadiotapHEData2) MidamblePeriodicityKnown() bool {
+	return r&RadiotapHEData2MidamblePeriodicityKnown != 0
 }
 
-func (self RadiotapHEData2) RUAllocationOffset() int {
-	return int(self&RadiotapHEData2RUAllocationOffset) >> 8
+func (r RadiotapHEData2) RUAllocationOffset() int {
+	return int(r&RadiotapHEData2RUAllocationOffset) >> 8
 }
 
-func (self RadiotapHEData2) RUAllocationOffsetKnown() bool {
-	return self&RadiotapHEData2RUAllocationOffsetKnown != 0
+func (r RadiotapHEData2) RUAllocationOffsetKnown() bool {
+	return r&RadiotapHEData2RUAllocationOffsetKnown != 0
 }
 
-func (self RadiotapHEData2) PriSec80MHz() bool {
-	return self&RadiotapHEData2PriSec80MHz != 0
+func (r RadiotapHEData2) PriSec80MHz() bool {
+	return r&RadiotapHEData2PriSec80MHz != 0
 }
 
 type RadiotapHEPriSec80MHz bool
@@ -1010,36 +1010,36 @@ const (
 	RadiotapHEData3STBC                   RadiotapHEData3 = 0x8000
 )
 
-func (self RadiotapHEData3) BSSColor() int {
-	return int(self & RadiotapHEData3BSSColorMask)
+func (r RadiotapHEData3) BSSColor() int {
+	return int(r & RadiotapHEData3BSSColorMask)
 }
 
-func (self RadiotapHEData3) BeamChange() bool {
-	return self&RadiotapHEData3BeamChange != 0
+func (r RadiotapHEData3) BeamChange() bool {
+	return r&RadiotapHEData3BeamChange != 0
 }
 
-func (self RadiotapHEData3) ULDL() bool {
-	return self&RadiotapHEData3ULDL != 0
+func (r RadiotapHEData3) ULDL() bool {
+	return r&RadiotapHEData3ULDL != 0
 }
 
-func (self RadiotapHEData3) DataMCS() uint8 {
-	return uint8((self & RadiotapHEData3DataMCSMask) >> 8)
+func (r RadiotapHEData3) DataMCS() uint8 {
+	return uint8((r & RadiotapHEData3DataMCSMask) >> 8)
 }
 
-func (self RadiotapHEData3) DataDCM() bool {
-	return self&RadiotapHEData3DataDCM != 0
+func (r RadiotapHEData3) DataDCM() bool {
+	return r&RadiotapHEData3DataDCM != 0
 }
 
-func (self RadiotapHEData3) Coding() RadiotapHECoding {
-	return self&RadiotapHEData3Coding != 0
+func (r RadiotapHEData3) Coding() RadiotapHECoding {
+	return r&RadiotapHEData3Coding != 0
 }
 
-func (self RadiotapHEData3) LDPCExtraSymbolSegment() bool {
-	return self&RadiotapHEData3LDPCEXtraSymbolSegment != 0
+func (r RadiotapHEData3) LDPCExtraSymbolSegment() bool {
+	return r&RadiotapHEData3LDPCEXtraSymbolSegment != 0
 }
 
-func (self RadiotapHEData3) STBC() bool {
-	return self&RadiotapHEData3STBC != 0
+func (r RadiotapHEData3) STBC() bool {
+	return r&RadiotapHEData3STBC != 0
 }
 
 type RadiotapHECoding bool
@@ -1237,20 +1237,20 @@ const (
 	RadiotapHEData6MidamblePeriodic RadiotapHEData6 = 0x8000
 )
 
-func (self RadiotapHEData6) NSTS() int {
-	return int(self & RadiotapHEData6NSTS)
+func (r RadiotapHEData6) NSTS() int {
+	return int(r & RadiotapHEData6NSTS)
 }
 
-func (self RadiotapHEData6) Doppler() bool {
-	return self&RadiotapHEData6Doppler != 0
+func (r RadiotapHEData6) Doppler() bool {
+	return r&RadiotapHEData6Doppler != 0
 }
 
-func (self RadiotapHEData6) TXOP() int {
-	return int((self & RadiotapHEData6TXOP) >> 8)
+func (r RadiotapHEData6) TXOP() int {
+	return int((r & RadiotapHEData6TXOP) >> 8)
 }
 
-func (self RadiotapHEData6) MidamblePeriodicity() MidamblePeriodicity {
-	return MidamblePeriodicity((self & RadiotapHEData6MidamblePeriodic) >> 15)
+func (r RadiotapHEData6) MidamblePeriodicity() MidamblePeriodicity {
+	return MidamblePeriodicity((r & RadiotapHEData6MidamblePeriodic) >> 15)
 }
 
 func decodeRadioTap(data []byte, p gopacket.PacketBuilder) error {
@@ -1315,7 +1315,7 @@ func (m *RadioTap) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) erro
 		df.SetTruncated()
 		return errors.New("RadioTap too small")
 	}
-	m.Version = uint8(data[0])
+	m.Version = data[0]
 	m.Length = binary.LittleEndian.Uint16(data[2:4])
 	m.Present = RadioTapPresent(binary.LittleEndian.Uint32(data[4:8]))
 
@@ -1386,15 +1386,15 @@ func (m *RadioTap) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) erro
 		offset++
 	}
 	if m.Present.Antenna() {
-		m.Antenna = uint8(data[offset])
+		m.Antenna = data[offset]
 		offset++
 	}
 	if m.Present.DBAntennaSignal() {
-		m.DBAntennaSignal = uint8(data[offset])
+		m.DBAntennaSignal = data[offset]
 		offset++
 	}
 	if m.Present.DBAntennaNoise() {
-		m.DBAntennaNoise = uint8(data[offset])
+		m.DBAntennaNoise = data[offset]
 		offset++
 	}
 	if m.Present.RxFlags() {
@@ -1408,18 +1408,18 @@ func (m *RadioTap) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) erro
 		offset += 2
 	}
 	if m.Present.RtsRetries() {
-		m.RtsRetries = uint8(data[offset])
+		m.RtsRetries = data[offset]
 		offset++
 	}
 	if m.Present.DataRetries() {
-		m.DataRetries = uint8(data[offset])
+		m.DataRetries = data[offset]
 		offset++
 	}
 	if m.Present.MCS() {
 		m.MCS = RadioTapMCS{
 			RadioTapMCSKnown(data[offset]),
 			RadioTapMCSFlags(data[offset+1]),
-			uint8(data[offset+2]),
+			data[offset+2],
 		}
 		offset += 3
 	}
@@ -1428,7 +1428,7 @@ func (m *RadioTap) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) erro
 		m.AMPDUStatus = RadioTapAMPDUStatus{
 			Reference: binary.LittleEndian.Uint32(data[offset:]),
 			Flags:     RadioTapAMPDUStatusFlags(binary.LittleEndian.Uint16(data[offset+4:])),
-			CRC:       uint8(data[offset+6]),
+			CRC:       data[offset+6],
 		}
 		offset += 8
 	}
@@ -1437,15 +1437,15 @@ func (m *RadioTap) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) erro
 		m.VHT = RadioTapVHT{
 			Known:     RadioTapVHTKnown(binary.LittleEndian.Uint16(data[offset:])),
 			Flags:     RadioTapVHTFlags(data[offset+2]),
-			Bandwidth: uint8(data[offset+3]),
+			Bandwidth: data[offset+3],
 			MCSNSS: [4]RadioTapVHTMCSNSS{
 				RadioTapVHTMCSNSS(data[offset+4]),
 				RadioTapVHTMCSNSS(data[offset+5]),
 				RadioTapVHTMCSNSS(data[offset+6]),
 				RadioTapVHTMCSNSS(data[offset+7]),
 			},
-			Coding:     uint8(data[offset+8]),
-			GroupId:    uint8(data[offset+9]),
+			Coding:     data[offset+8],
+			GroupId:    data[offset+9],
 			PartialAID: binary.LittleEndian.Uint16(data[offset+10:]),
 		}
 		offset += 12
@@ -1583,17 +1583,17 @@ func (m RadioTap) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serializ
 	}
 
 	if m.Present.Antenna() {
-		buf[offset] = uint8(m.Antenna)
+		buf[offset] = m.Antenna
 		offset++
 	}
 
 	if m.Present.DBAntennaSignal() {
-		buf[offset] = uint8(m.DBAntennaSignal)
+		buf[offset] = m.DBAntennaSignal
 		offset++
 	}
 
 	if m.Present.DBAntennaNoise() {
-		buf[offset] = uint8(m.DBAntennaNoise)
+		buf[offset] = m.DBAntennaNoise
 		offset++
 	}
 
@@ -1622,7 +1622,7 @@ func (m RadioTap) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serializ
 	if m.Present.MCS() {
 		buf[offset] = uint8(m.MCS.Known)
 		buf[offset+1] = uint8(m.MCS.Flags)
-		buf[offset+2] = uint8(m.MCS.MCS)
+		buf[offset+2] = m.MCS.MCS
 
 		offset += 3
 	}
@@ -1644,13 +1644,13 @@ func (m RadioTap) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serializ
 		binary.LittleEndian.PutUint16(buf[offset:], uint16(m.VHT.Known))
 
 		buf[offset+2] = uint8(m.VHT.Flags)
-		buf[offset+3] = uint8(m.VHT.Bandwidth)
+		buf[offset+3] = m.VHT.Bandwidth
 		buf[offset+4] = uint8(m.VHT.MCSNSS[0])
 		buf[offset+5] = uint8(m.VHT.MCSNSS[1])
 		buf[offset+6] = uint8(m.VHT.MCSNSS[2])
 		buf[offset+7] = uint8(m.VHT.MCSNSS[3])
-		buf[offset+8] = uint8(m.VHT.Coding)
-		buf[offset+9] = uint8(m.VHT.GroupId)
+		buf[offset+8] = m.VHT.Coding
+		buf[offset+9] = m.VHT.GroupId
 
 		binary.LittleEndian.PutUint16(buf[offset+10:offset+12], m.VHT.PartialAID)
 

--- a/layers/usb.go
+++ b/layers/usb.go
@@ -128,13 +128,13 @@ type USB struct {
 
 func (u *USB) LayerType() gopacket.LayerType { return LayerTypeUSB }
 
-func (m *USB) NextLayerType() gopacket.LayerType {
-	if m.Setup {
+func (u *USB) NextLayerType() gopacket.LayerType {
+	if u.Setup {
 		return LayerTypeUSBRequestBlockSetup
-	} else if m.Data {
+	} else if u.Data {
 	}
 
-	return m.TransferType.LayerType()
+	return u.TransferType.LayerType()
 }
 
 func decodeUSB(data []byte, p gopacket.PacketBuilder) error {
@@ -143,56 +143,56 @@ func decodeUSB(data []byte, p gopacket.PacketBuilder) error {
 	return decodingLayerDecoder(d, data, p)
 }
 
-func (m *USB) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+func (u *USB) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 40 {
 		df.SetTruncated()
 		return errors.New("USB < 40 bytes")
 	}
-	m.ID = binary.LittleEndian.Uint64(data[0:8])
-	m.EventType = USBEventType(data[8])
-	m.TransferType = USBTransportType(data[9])
+	u.ID = binary.LittleEndian.Uint64(data[0:8])
+	u.EventType = USBEventType(data[8])
+	u.TransferType = USBTransportType(data[9])
 
-	m.EndpointNumber = data[10] & 0x7f
+	u.EndpointNumber = data[10] & 0x7f
 	if data[10]&uint8(USBTransportTypeTransferIn) > 0 {
-		m.Direction = USBDirectionTypeIn
+		u.Direction = USBDirectionTypeIn
 	} else {
-		m.Direction = USBDirectionTypeOut
+		u.Direction = USBDirectionTypeOut
 	}
 
-	m.DeviceAddress = data[11]
-	m.BusID = binary.LittleEndian.Uint16(data[12:14])
+	u.DeviceAddress = data[11]
+	u.BusID = binary.LittleEndian.Uint16(data[12:14])
 
 	if uint(data[14]) == 0 {
-		m.Setup = true
+		u.Setup = true
 	}
 
 	if uint(data[15]) == 0 {
-		m.Data = true
+		u.Data = true
 	}
 
-	m.TimestampSec = int64(binary.LittleEndian.Uint64(data[16:24]))
-	m.TimestampUsec = int32(binary.LittleEndian.Uint32(data[24:28]))
-	m.Status = int32(binary.LittleEndian.Uint32(data[28:32]))
-	m.UrbLength = binary.LittleEndian.Uint32(data[32:36])
-	m.UrbDataLength = binary.LittleEndian.Uint32(data[36:40])
+	u.TimestampSec = int64(binary.LittleEndian.Uint64(data[16:24]))
+	u.TimestampUsec = int32(binary.LittleEndian.Uint32(data[24:28]))
+	u.Status = int32(binary.LittleEndian.Uint32(data[28:32]))
+	u.UrbLength = binary.LittleEndian.Uint32(data[32:36])
+	u.UrbDataLength = binary.LittleEndian.Uint32(data[36:40])
 
-	m.Contents = data[:40]
-	m.Payload = data[40:]
+	u.Contents = data[:40]
+	u.Payload = data[40:]
 
-	if m.Setup {
-		m.Payload = data[40:]
-	} else if m.Data {
-		m.Payload = data[uint32(len(data))-m.UrbDataLength:]
+	if u.Setup {
+		u.Payload = data[40:]
+	} else if u.Data {
+		u.Payload = data[uint32(len(data))-u.UrbDataLength:]
 	}
 
 	// if 64 bit, dissect_linux_usb_pseudo_header_ext
 	if false {
-		m.UrbInterval = binary.LittleEndian.Uint32(data[40:44])
-		m.UrbStartFrame = binary.LittleEndian.Uint32(data[44:48])
-		m.UrbDataLength = binary.LittleEndian.Uint32(data[48:52])
-		m.IsoNumDesc = binary.LittleEndian.Uint32(data[52:56])
-		m.Contents = data[:56]
-		m.Payload = data[56:]
+		u.UrbInterval = binary.LittleEndian.Uint32(data[40:44])
+		u.UrbStartFrame = binary.LittleEndian.Uint32(data[44:48])
+		u.UrbDataLength = binary.LittleEndian.Uint32(data[48:52])
+		u.IsoNumDesc = binary.LittleEndian.Uint32(data[52:56])
+		u.Contents = data[:56]
+		u.Payload = data[56:]
 	}
 
 	// crc5 or crc16
@@ -212,18 +212,18 @@ type USBRequestBlockSetup struct {
 
 func (u *USBRequestBlockSetup) LayerType() gopacket.LayerType { return LayerTypeUSBRequestBlockSetup }
 
-func (m *USBRequestBlockSetup) NextLayerType() gopacket.LayerType {
+func (u *USBRequestBlockSetup) NextLayerType() gopacket.LayerType {
 	return gopacket.LayerTypePayload
 }
 
-func (m *USBRequestBlockSetup) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	m.RequestType = data[0]
-	m.Request = USBRequestBlockSetupRequest(data[1])
-	m.Value = binary.LittleEndian.Uint16(data[2:4])
-	m.Index = binary.LittleEndian.Uint16(data[4:6])
-	m.Length = binary.LittleEndian.Uint16(data[6:8])
-	m.Contents = data[:8]
-	m.Payload = data[8:]
+func (u *USBRequestBlockSetup) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	u.RequestType = data[0]
+	u.Request = USBRequestBlockSetupRequest(data[1])
+	u.Value = binary.LittleEndian.Uint16(data[2:4])
+	u.Index = binary.LittleEndian.Uint16(data[4:6])
+	u.Length = binary.LittleEndian.Uint16(data[6:8])
+	u.Contents = data[:8]
+	u.Payload = data[8:]
 	return nil
 }
 
@@ -238,12 +238,12 @@ type USBControl struct {
 
 func (u *USBControl) LayerType() gopacket.LayerType { return LayerTypeUSBControl }
 
-func (m *USBControl) NextLayerType() gopacket.LayerType {
+func (u *USBControl) NextLayerType() gopacket.LayerType {
 	return gopacket.LayerTypePayload
 }
 
-func (m *USBControl) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	m.Contents = data
+func (u *USBControl) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	u.Contents = data
 	return nil
 }
 
@@ -258,12 +258,12 @@ type USBInterrupt struct {
 
 func (u *USBInterrupt) LayerType() gopacket.LayerType { return LayerTypeUSBInterrupt }
 
-func (m *USBInterrupt) NextLayerType() gopacket.LayerType {
+func (u *USBInterrupt) NextLayerType() gopacket.LayerType {
 	return gopacket.LayerTypePayload
 }
 
-func (m *USBInterrupt) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	m.Contents = data
+func (u *USBInterrupt) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	u.Contents = data
 	return nil
 }
 
@@ -278,12 +278,12 @@ type USBBulk struct {
 
 func (u *USBBulk) LayerType() gopacket.LayerType { return LayerTypeUSBBulk }
 
-func (m *USBBulk) NextLayerType() gopacket.LayerType {
+func (u *USBBulk) NextLayerType() gopacket.LayerType {
 	return gopacket.LayerTypePayload
 }
 
-func (m *USBBulk) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	m.Contents = data
+func (u *USBBulk) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	u.Contents = data
 	return nil
 }
 

--- a/layertype.go
+++ b/layertype.go
@@ -84,28 +84,28 @@ func OverrideLayerType(num int, meta LayerTypeMetadata) LayerType {
 
 // Decode decodes the given data using the decoder registered with the layer
 // type.
-func (t LayerType) Decode(data []byte, c PacketBuilder) error {
+func (l LayerType) Decode(data []byte, c PacketBuilder) error {
 	var d Decoder
-	if 0 <= int(t) && int(t) < maxLayerType {
-		d = ltMeta[int(t)].Decoder
+	if 0 <= int(l) && int(l) < maxLayerType {
+		d = ltMeta[int(l)].Decoder
 	} else {
-		d = ltMetaMap[t].Decoder
+		d = ltMetaMap[l].Decoder
 	}
 	if d != nil {
 		return d.Decode(data, c)
 	}
-	return fmt.Errorf("Layer type %v has no associated decoder", t)
+	return fmt.Errorf("Layer type %v has no associated decoder", l)
 }
 
 // String returns the string associated with this layer type.
-func (t LayerType) String() (s string) {
-	if 0 <= int(t) && int(t) < maxLayerType {
-		s = ltMeta[int(t)].Name
+func (l LayerType) String() (s string) {
+	if 0 <= int(l) && int(l) < maxLayerType {
+		s = ltMeta[int(l)].Name
 	} else {
-		s = ltMetaMap[t].Name
+		s = ltMetaMap[l].Name
 	}
 	if s == "" {
-		s = strconv.Itoa(int(t))
+		s = strconv.Itoa(int(l))
 	}
 	return
 }

--- a/parser.go
+++ b/parser.go
@@ -75,14 +75,14 @@ type DecodingLayerSparse []DecodingLayer
 
 // Put implements DecodingLayerContainer interface.
 func (dl DecodingLayerSparse) Put(d DecodingLayer) DecodingLayerContainer {
-	maxLayerType := LayerType(len(dl) - 1)
+	maxLayerTypeLen := LayerType(len(dl) - 1)
 	for _, typ := range d.CanDecode().LayerTypes() {
-		if typ > maxLayerType {
-			maxLayerType = typ
+		if typ > maxLayerTypeLen {
+			maxLayerTypeLen = typ
 		}
 	}
 
-	if extra := maxLayerType - LayerType(len(dl)) + 1; extra > 0 {
+	if extra := maxLayerTypeLen - LayerType(len(dl)) + 1; extra > 0 {
 		dl = append(dl, make([]DecodingLayer, extra)...)
 	}
 

--- a/pcapgo/ngread.go
+++ b/pcapgo/ngread.go
@@ -429,7 +429,7 @@ func (r *NgReader) readInterfaceStatistics() error {
 	r.currentBlock.length -= 12
 	ifaceID := int(r.getUint32(r.buf[:4]))
 	ts := uint64(r.getUint32(r.buf[4:8]))<<32 | uint64(r.getUint32(r.buf[8:12]))
-	if int(ifaceID) >= len(r.ifaces) {
+	if ifaceID >= len(r.ifaces) {
 		return fmt.Errorf("Interface id %d not present in section (have only %d interfaces)", ifaceID, len(r.ifaces))
 	}
 	stats := &r.ifaces[ifaceID].Statistics

--- a/writer.go
+++ b/writer.go
@@ -205,10 +205,13 @@ func (w *serializeBuffer) PushLayer(l LayerType) {
 //	gopacket.SerializeLayers(buf, opts, d, e, f)
 //	secondPayload := buf.Bytes()  // contains byte representation of d(e(f)). firstPayload is now invalidated, since the SerializeLayers call Clears buf.
 func SerializeLayers(w SerializeBuffer, opts SerializeOptions, layers ...SerializableLayer) error {
-	w.Clear()
+	err := w.Clear()
+	if err != nil {
+		return err
+	}
 	for i := len(layers) - 1; i >= 0; i-- {
 		layer := layers[i]
-		err := layer.SerializeTo(w, opts)
+		err = layer.SerializeTo(w, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Remove redundant type convert, such as: `uint8` -> `byte`.
- Remove redundant parentheses, such as: `h |= (uint8(d.State) << 6)` -> `h |= uint8(d.State) << 6`.
- Remove redundant index: `data[:len(data)]` -> `data[:]`
- Uniform method's receiver name.