### PR TITLE
endian: fix big endian detection

### DIFF
--- a/endian/endian.go
+++ b/endian/endian.go
@@ -5,16 +5,14 @@ import (
 	"math/bits"
 )
 
-func hostUsesNetByteorder() bool {
-	// Compiler eliminates string comparison since it knows both values
-	// at compile time, https://godbolt.org/z/YKKrEdGEx
-	return binary.NativeEndian.String() == binary.BigEndian.String()
+func isLittleEndian[Bo binary.ByteOrder](bo Bo) bool {
+	return bo.Uint16([]byte{0x12, 0x34}) == 0x3412
 }
 
 // Htons converts x from host to network byte order.
 func Htons(v uint16) uint16 {
-	if hostUsesNetByteorder() {
-		return v
+	if isLittleEndian(binary.NativeEndian) {
+		return bits.ReverseBytes16(v)
 	}
-	return bits.ReverseBytes16(v)
+	return v
 }

--- a/endian/endian_test.go
+++ b/endian/endian_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 )
 
-func TestHostUsesNetByteorder(t *testing.T) {
-	buf := [2]byte{0, 42}
-	hostIsNet := 42 == binary.NativeEndian.Uint16(buf[:])
-	if hostIsNet != hostUsesNetByteorder() {
-		t.Errorf("hostUsesNetByteorder: want %v, got %v", hostIsNet, hostUsesNetByteorder())
+func TestIsLittleEndian(t *testing.T) {
+	if !isLittleEndian(binary.LittleEndian) {
+		t.Error("binary.LittleEndian was not detected as little endian")
+	}
+	if isLittleEndian(binary.BigEndian) {
+		t.Error("binary.BigEndian was detected as little endian")
 	}
 }
 


### PR DESCRIPTION
The prior implementation of Htons attempted big endian detection via comparison of binary.NativeEndian.String() with binary.BigEndian.String(). It turns out that the former always returns "NativeEndian", hence it didn't work as intended.

Rewrite endian detection by passing []byte{0x12, 0x34} through Endian.Uint16(). Add test to ensure that detection works both on little and big endian CPUs.