### PR TITLE
Feature/add serialize to i pv6 routing

### DIFF
--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -563,6 +563,27 @@ type IPv6Routing struct {
 // LayerType returns LayerTypeIPv6Routing.
 func (i *IPv6Routing) LayerType() gopacket.LayerType { return LayerTypeIPv6Routing }
 
+// SerializeTo implementation according to gopacket.SerializableLayer
+func (i *IPv6Routing) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	totalLen := 8 + len(i.SourceRoutingIPs)*16
+	hdrExtLen := (totalLen - 8) / 8
+
+	bytes, err := b.PrependBytes(totalLen)
+	if err != nil {
+		return err
+	}
+	bytes[0] = byte(i.ipv6ExtensionBase.NextHeader)
+	bytes[1] = byte(hdrExtLen)
+	bytes[2] = i.RoutingType
+	bytes[3] = i.SegmentsLeft
+	copy(bytes[4:8], i.Reserved)
+	for i, ip := range i.SourceRoutingIPs {
+		offset := 8 + i*16
+		copy(bytes[offset:offset+16], ip.To16())
+	}
+	return nil
+}
+
 func decodeIPv6Routing(data []byte, p gopacket.PacketBuilder) error {
 	base, err := decodeIPv6ExtensionBase(data, p)
 	if err != nil {


### PR DESCRIPTION
Add implementation `SerializeTo` to [`IPv6Routing`](https://pkg.go.dev/github.com/gopacket/gopacket@v1.3.1/layers#IPv6Routing)

https://github.com/gopacket/gopacket/issues/106