### PR TITLE
gtpv1u: check message type when decoding payload

### DIFF
--- a/layers/gtp.go
+++ b/layers/gtp.go
@@ -176,6 +176,9 @@ func (g *GTPv1U) NextLayerType() gopacket.LayerType {
 	if len(g.LayerPayload()) == 0 {
 		return gopacket.LayerTypeZero
 	}
+	if g.MessageType != 255 {
+		return gopacket.LayerTypePayload
+	}
 	version := uint8(g.LayerPayload()[0]) >> 4
 	if version == 4 {
 		return LayerTypeIPv4


### PR DESCRIPTION
GTPv1U has different message types. Data (255) carries nested IPv4, IPv6 or PPP packet.  Other messages such as Echo Request / Response don't.

Check the message type first and only parse payload as IPv4 / IPv6 / PPP in data PDUs.