### PR TITLE
geneve: implement DecodingLayer

### DIFF
--- a/layers/geneve.go
+++ b/layers/geneve.go
@@ -50,6 +50,9 @@ type GeneveOption struct {
 	Data   []byte
 }
 
+// ensure Geneve implements DecodingLayer.
+var _ gopacket.DecodingLayer = (*Geneve)(nil)
+
 // LayerType returns LayerTypeGeneve
 func (gn *Geneve) LayerType() gopacket.LayerType { return LayerTypeGeneve }
 
@@ -191,4 +194,9 @@ func (gn *Geneve) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serializ
 	}
 
 	return nil
+}
+
+// CanDecode implements DecodingLayer.
+func (gn *Geneve) CanDecode() gopacket.LayerClass {
+	return LayerTypeGeneve
 }

--- a/layers/geneve_test.go
+++ b/layers/geneve_test.go
@@ -374,3 +374,7 @@ func TestIsomorphicPacketGeneveFixLengths(t *testing.T) {
 		t.Errorf("Geneve isomorph mismatch, \nwant %#v\ngot %#v\n", gn, gnTranslated)
 	}
 }
+
+func TestGeneveAsDecodingLayer(t *testing.T) {
+	_ = gopacket.NewDecodingLayerParser(LayerTypeGeneve, &Geneve{})
+}


### PR DESCRIPTION
Before this patch, the Geneve layer would not fully implement `DecodingLayer`. This would prevent Geneve to be added as a `DecodingLayer` to `gopacket.NewDecodingLayerParser()`:

    cannot use &Geneve{} (value of type *Geneve) as gopacket.DecodingLayer value in argument to gopacket.NewDecodingLayerParser: *Geneve does not implement gopacket.DecodingLayer (missing method CanDecode)

This patch implements `(*Geneve).CanDecode()` and a test to ensure Geneve can be used as a `DecodingLayer`.