### PR TITLE
ipsec: implement DecodingLayer

### DIFF
--- a/layers/ipsec.go
+++ b/layers/ipsec.go
@@ -29,29 +29,46 @@ type IPSecAH struct {
 func (i *IPSecAH) LayerType() gopacket.LayerType { return LayerTypeIPSecAH }
 
 func decodeIPSecAH(data []byte, p gopacket.PacketBuilder) error {
+	i := &IPSecAH{}
+	return decodingLayerDecoder(i, data, p)
+}
+
+// DecodeFromBytes takes a byte buffer and decodes
+func (i *IPSecAH) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 12 {
-		p.SetTruncated()
+		df.SetTruncated()
 		return errors.New("IPSec AH packet less than 12 bytes")
 	}
-	i := &IPSecAH{
-		ipv6ExtensionBase: ipv6ExtensionBase{
-			NextHeader:   IPProtocol(data[0]),
-			HeaderLength: data[1],
-		},
-		Reserved: binary.BigEndian.Uint16(data[2:4]),
-		SPI:      binary.BigEndian.Uint32(data[4:8]),
-		Seq:      binary.BigEndian.Uint32(data[8:12]),
+
+	i.ipv6ExtensionBase = ipv6ExtensionBase{
+		NextHeader:   IPProtocol(data[0]),
+		HeaderLength: data[1],
 	}
+
+	i.Reserved = binary.BigEndian.Uint16(data[2:4])
+	i.SPI = binary.BigEndian.Uint32(data[4:8])
+	i.Seq = binary.BigEndian.Uint32(data[8:12])
+
 	i.ActualLength = (int(i.HeaderLength) + 2) * 4
 	if len(data) < i.ActualLength {
-		p.SetTruncated()
+		df.SetTruncated()
 		return errors.New("Truncated AH packet < ActualLength")
 	}
 	i.AuthenticationData = data[12:i.ActualLength]
 	i.Contents = data[:i.ActualLength]
 	i.Payload = data[i.ActualLength:]
-	p.AddLayer(i)
-	return p.NextDecoder(i.NextHeader)
+
+	return nil
+}
+
+// CanDecode returns the layer type this DecodingLayer can decode
+func (i *IPSecAH) CanDecode() gopacket.LayerClass {
+	return LayerTypeIPSecAH
+}
+
+// NextLayerType retuns the next layer we should see after IPSecAH
+func (i *IPSecAH) NextLayerType() gopacket.LayerType {
+	return i.NextHeader.LayerType()
 }
 
 // IPSecESP is the encapsulating security payload defined in
@@ -67,12 +84,31 @@ type IPSecESP struct {
 func (i *IPSecESP) LayerType() gopacket.LayerType { return LayerTypeIPSecESP }
 
 func decodeIPSecESP(data []byte, p gopacket.PacketBuilder) error {
-	i := &IPSecESP{
-		BaseLayer: BaseLayer{data, nil},
-		SPI:       binary.BigEndian.Uint32(data[:4]),
-		Seq:       binary.BigEndian.Uint32(data[4:8]),
-		Encrypted: data[8:],
+	i := &IPSecESP{}
+	return decodingLayerDecoder(i, data, p)
+}
+
+// DecodeFromBytes takes a byte buffer and decodes
+func (i *IPSecESP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 8 {
+		df.SetTruncated()
+		return errors.New("IPSec ESP packet less than 8 bytes")
 	}
-	p.AddLayer(i)
+
+	i.BaseLayer = BaseLayer{data, nil}
+	i.SPI = binary.BigEndian.Uint32(data[:4])
+	i.Seq = binary.BigEndian.Uint32(data[4:8])
+	i.Encrypted = data[8:]
+
 	return nil
+}
+
+// CanDecode returns the layer type this DecodingLayer can decode
+func (i *IPSecESP) CanDecode() gopacket.LayerClass {
+	return LayerTypeIPSecESP
+}
+
+// NextLayerType retuns the next layer we should see after IPSecESP
+func (i *IPSecESP) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypePayload
 }

--- a/layers/ipsec.go
+++ b/layers/ipsec.go
@@ -66,7 +66,7 @@ func (i *IPSecAH) CanDecode() gopacket.LayerClass {
 	return LayerTypeIPSecAH
 }
 
-// NextLayerType retuns the next layer we should see after IPSecAH
+// NextLayerType returns the next layer we should see after IPSecAH
 func (i *IPSecAH) NextLayerType() gopacket.LayerType {
 	return i.NextHeader.LayerType()
 }

--- a/layers/ipsec_test.go
+++ b/layers/ipsec_test.go
@@ -117,6 +117,10 @@ func BenchmarkDecodePacketIPSecAHTunnel(b *testing.B) {
 	}
 }
 
+func TestIPSecAHAsDecodingLayer(t *testing.T) {
+	_ = gopacket.NewDecodingLayerParser(LayerTypeIPSecAH, &IPSecAH{})
+}
+
 // testPacketIPSecESP is the packet:
 //
 //	04:30:37.629376 IP 190.0.0.1 > 190.0.0.2: ESP(spi=0x0000006e,seq=0x13), length 116
@@ -155,4 +159,8 @@ func BenchmarkDecodePacketIPSecESP(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		gopacket.NewPacket(testPacketIPSecESP, LinkTypeEthernet, gopacket.NoCopy)
 	}
+}
+
+func TestIPSecESPAsDecodingLayer(t *testing.T) {
+	_ = gopacket.NewDecodingLayerParser(LayerTypeIPSecESP, &IPSecESP{})
 }


### PR DESCRIPTION
Before this patch, the IPSecAH and IPSecESP layer would not fully implement DecodingLayer. This would prevent them to be added as a DecodingLayer to gopacket.NewDecodingLayerParser():

    cannot use &IPSecAH{} (value of type *IPSecAH) as gopacket.DecodingLayer value in argument to gopacket.NewDecodingLayerParser: *IPSecAH does not implement gopacket.DecodingLayer (missing method CanDecode)

This patch implements (*IPSecAH).CanDecode() and (*IPSecESP).CanDecode() and a test to ensure they can be used as a DecodingLayer.