### PR TITLE
afpacket: add vnet_hdr_size option that can be passed to NewTPacket

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -193,7 +193,7 @@ func (h *TPacket) setRequestedTPacketVersion() error {
 	return nil
 }
 
-// setTPacketVersion tries to enable virtio_net_hdr support for the socket and sets the used size.
+// setVNetHdrSize tries to enable virtio_net_hdr support for the socket and sets the used size.
 func (h *TPacket) setVNetHdrSize(size int) error {
 	if err := unix.SetsockoptInt(h.fd, unix.SOL_PACKET, unix.PACKET_VNET_HDR_SZ, size); err != nil {
 		return fmt.Errorf("setsockopt packet_vnet_hdr_sz: %v", err)

--- a/afpacket/options.go
+++ b/afpacket/options.go
@@ -110,7 +110,7 @@ type OptAddVLANHeader bool
 // OptVNetHdrSize is the size of the virtio_net_hdr that all packets on the
 // socket will be prepended with. When this option is unset or zero, packets on
 // the socket will not use a virtio_net_hdr.
-// Valid sizes are either 10 or 12, depending on whether the num_buffers field
+// Common sizes are either 10 or 12, depending on whether the num_buffers field
 // is needed.
 type OptVNetHdrSize int
 


### PR DESCRIPTION
This new option allows to optionally prepend packets with a `virtio_net_hdr` of the given size. This is useful to use offloads over the packet socket.

More information: https://lwn.net/Articles/373209/