### PR TITLE
Add MPTCP option length check

### DIFF
--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -347,6 +347,9 @@ OPTIONS:
 		case TCPOptionKindMultipathTCP:
 			tcp.Multipath = true
 			opt.OptionLength = data[1]
+			if opt.OptionLength <= 0 {
+				return fmt.Errorf("MPTCP bad option length %d", opt.OptionLength)
+			}
 			opt.OptionMultipath = MPTCPSubtype(data[2] >> 4)
 			switch opt.OptionMultipath {
 			case MPTCPSubtypeMPCAPABLE:


### PR DESCRIPTION
This pull request adds a check and test case for MPTCP that ensures that zero-length options do not get processed, preventing infinite allocations. Closes issue #143 .