### PR TITLE
Differentiate between expected and unexpected EOFs in NgReader

### DIFF
--- a/pcapgo/ngread_dsb.go
+++ b/pcapgo/ngread_dsb.go
@@ -16,7 +16,7 @@ type decryptionSecret struct {
 
 // readDecryptionSecrets parses an encryption secrets section from the given
 func (r *NgReader) readDecryptionSecretsBlock() error {
-	if err := r.readBytes(r.buf[:8]); err != nil {
+	if _, err := r.readBytes(r.buf[:8]); err != nil {
 		return fmt.Errorf("could not read DecryptionSecret Header block length: %v", err)
 	}
 	r.currentBlock.length -= 8
@@ -25,7 +25,7 @@ func (r *NgReader) readDecryptionSecretsBlock() error {
 	decryptionSecretsBlock.secretsType = r.getUint32(r.buf[0:4])
 	decryptionSecretsBlock.secretsLength = r.getUint32(r.buf[4:8])
 	var payload = make([]byte, decryptionSecretsBlock.secretsLength)
-	if err := r.readBytes(payload); err != nil {
+	if _, err := r.readBytes(payload); err != nil {
 		return fmt.Errorf("could not read %d bytes from DecryptionSecret payload: %v", decryptionSecretsBlock.secretsLength, err)
 	}
 	r.currentBlock.length -= uint32(len(payload))

--- a/pcapgo/ngread_nrb.go
+++ b/pcapgo/ngread_nrb.go
@@ -46,7 +46,7 @@ func newHWAddress(data []byte) *NgEUIAddress {
 }
 
 func (r *NgReader) readIPAddr(nr *NgNameRecord, length int) error {
-	if err := r.readBytes(r.buf[:length]); err != nil {
+	if _, err := r.readBytes(r.buf[:length]); err != nil {
 		return fmt.Errorf("could not read IP address: %v", err)
 	}
 	nr.Addr = newIPAddress(r.buf[:length])
@@ -54,18 +54,10 @@ func (r *NgReader) readIPAddr(nr *NgNameRecord, length int) error {
 }
 
 func (r *NgReader) readHWAddr(nr *NgNameRecord, length int) error {
-	if err := r.readBytes(r.buf[:length]); err != nil {
+	if _, err := r.readBytes(r.buf[:length]); err != nil {
 		return fmt.Errorf("could not read EUI address: %v", err)
 	}
 	nr.Addr = newHWAddress(r.buf[:])
-	return nil
-}
-
-func (r *NgReader) discard(length int) error {
-	if _, err := r.r.Discard(length); err != nil {
-		return fmt.Errorf("could not discard %d bytes: %v", length, err)
-	}
-	r.currentBlock.length -= uint32(length)
 	return nil
 }
 
@@ -73,7 +65,7 @@ func (r *NgReader) readNameResolutionBlock() error {
 
 	for r.currentBlock.length > 0 {
 		// Read name record header
-		if err := r.readBytes(r.buf[:4]); err != nil {
+		if _, err := r.readBytes(r.buf[:4]); err != nil {
 			return fmt.Errorf("could not read NameRecord Header block length: %v", err)
 		}
 		r.currentBlock.length -= 4

--- a/pcapgo/ngread_test.go
+++ b/pcapgo/ngread_test.go
@@ -1947,6 +1947,7 @@ func TestTruncatedDiscard(t *testing.T) {
 		return
 	} else {
 		t.Error("Expected io.ErrUnexpectedEOF, got:", err)
+		t.FailNow()
 	}
 }
 

--- a/pcapgo/ngread_test.go
+++ b/pcapgo/ngread_test.go
@@ -1881,14 +1881,82 @@ func TestNgFileReadGzipPacket(t *testing.T) {
 }
 
 func TestNgFileReadTruncatedGzipPacket(t *testing.T) {
-	test := []byte{
-		0x1f, 0x8b, 0x08,
+	type ngGzipTruncTest struct {
+		data        []byte
+		expectErr   error
+		description string
 	}
 
-	buf := bytes.NewBuffer(test)
+	tests := []ngGzipTruncTest{
+		{
+			data:        []byte{},
+			expectErr:   io.EOF,
+			description: "Empty data",
+		},
+		{
+			data:        []byte{0x1f},
+			expectErr:   io.ErrUnexpectedEOF,
+			description: "Partial GZIP Header",
+		},
+		{
+			data:        []byte{0x1f, 0x8b, 0x08},
+			expectErr:   io.ErrUnexpectedEOF,
+			description: "3 bytes of gzip header, missing rest",
+		},
+	}
+	for _, test := range tests {
+		buf := bytes.NewBuffer(test.data)
+		_, err := NewNgReader(buf, DefaultNgReaderOptions)
+		if err != test.expectErr {
+			t.Errorf("Test '%s' failed: expected error %v, got %v", test.description, test.expectErr, err)
+		}
+	}
+}
 
-	if _, err := NewNgReader(buf, DefaultNgReaderOptions); err == nil {
-		t.Error("Should fail but did not")
+func getBasicOnePacketPcap(t *testing.T) *bytes.Buffer {
+	var buf bytes.Buffer
+	w, err := NewNgWriter(&buf, layers.LinkTypeEthernet)
+	if err != nil {
+		t.Error("Unexpected error returned:", err)
+		t.FailNow()
+	}
+	err = w.WritePacket(gopacket.CaptureInfo{CaptureLength: 2, Length: 2}, []byte{1, 2})
+	if err != nil {
+		t.Error("Unexpected error returned:", err)
+		t.FailNow()
+	}
+	err = w.Flush()
+	if err != nil {
+		t.Error("Unexpected error returned:", err)
+		t.FailNow()
+	}
+	return &buf
+}
+
+// Tests that NgReader buffer discard passes along UnexpectedEOF to callers
+func TestTruncatedDiscard(t *testing.T) {
+	buf := getBasicOnePacketPcap(t)
+	buf.Truncate(buf.Len() - 1) // truncate last byte to simulate incomplete file
+	r, err := NewNgReader(buf, DefaultNgReaderOptions)
+	if err != nil {
+		t.Error("Unexpected error returned:", err)
+		t.FailNow()
+	}
+	_, _, err = r.ReadPacketData()
+	if err == io.ErrUnexpectedEOF {
+		return
+	} else {
+		t.Error("Expected io.ErrUnexpectedEOF, got:", err)
+	}
+}
+
+// Tests that truncated block headers return UnexpectedEOF
+func TestTruncatedBlockHeader(t *testing.T) {
+	buf := getBasicOnePacketPcap(t)
+	buf.Truncate(4) // truncate to half of the block header
+	_, err := NewNgReader(buf, DefaultNgReaderOptions)
+	if err != io.ErrUnexpectedEOF {
+		t.Error("Expected io.ErrUnexpectedEOF, got:", err)
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
Because `readBytes` and `Discard` were used in so many places it made more sense to have these return `UnexpectedEOF` and then explicitly downgrade this to `EOF` in the two places where it's expected (blank file and no bytes at start of block). Because of this second case it was necessary to have `readBytes` return the number of bytes read, which increased the number of lines changed.

I've expanded the test suite to cover these cases as well.

Fixes #149 