### PR TITLE
fix(lcm): add bounds check around fingerprint

### DIFF
--- a/layers/lcm.go
+++ b/layers/lcm.go
@@ -166,8 +166,10 @@ func (lcm *LCM) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		lcm.ChannelName = string(buffer)
 	}
 
-	lcm.fingerprint = LCMFingerprint(
-		binary.BigEndian.Uint64(data[offset : offset+8]))
+	if len(data)-offset >= 8 {
+		lcm.fingerprint = LCMFingerprint(
+			binary.BigEndian.Uint64(data[offset : offset+8]))
+	}
 
 	lcm.contents = data[:offset]
 	lcm.payload = data[offset:]

--- a/layers/lcm_test.go
+++ b/layers/lcm_test.go
@@ -34,12 +34,20 @@ var (
 	}
 
 	expectedChannel = "LCM_SELF_TEST"
+
+	// Short header with channel name but no fingerprint bytes after it
+	shortPacketEmptyPayload = []byte{
+		0x4c, 0x43, 0x30, 0x32, // magic
+		0x00, 0x00, 0x00, 0x00, // sequence number
+		0x4c, 0x43, 0x4d, 0x00, // channel "LCM" + null terminator
+	}
 )
 
 func TestLCMDecode(t *testing.T) {
 	testShortLCM(t)
 	testFragmentedLCM(t)
 	testInvalidLCM(t)
+	testEmptyPayloadLCM(t)
 }
 
 func testShortLCM(t *testing.T) {
@@ -152,5 +160,26 @@ func testInvalidLCM(t *testing.T) {
 	err := lcm.DecodeFromBytes(invalidPacket, gopacket.NilDecodeFeedback)
 	if err == nil {
 		t.Fatal("Did not detect LCM decode error.")
+	}
+}
+
+func testEmptyPayloadLCM(t *testing.T) {
+	lcm := LCM{}
+
+	err := lcm.DecodeFromBytes(shortPacketEmptyPayload, gopacket.NilDecodeFeedback)
+	if err != nil {
+		t.Fatalf("Unexpected error decoding LCM packet with empty payload: %v", err)
+	}
+
+	if lcm.ChannelName != "LCM" {
+		t.Errorf("Expected channel name %q but received %q", "LCM", lcm.ChannelName)
+	}
+
+	if lcm.Fingerprint() != 0 {
+		t.Errorf("Expected zero fingerprint but received %x", lcm.Fingerprint())
+	}
+
+	if len(lcm.Payload()) != 0 {
+		t.Errorf("Expected empty payload but received %d bytes", len(lcm.Payload()))
 	}
 }


### PR DESCRIPTION
# Description
The LCM layer decoder in `layers/lcm.go` unconditionally reads 8 bytes for the type fingerprint after parsing the channel name, without first checking that enough data remains. This causes a slice bounds out-of-range panic if the LCM message payload is fewer than 8 bytes.

The LCM transport protocol does not require a minimum payload size — the raw `lcm_publish` API accepts a zero-length data buffer, producing a valid on-the-wire packet containing only the header and channel name with no payload. The 8-byte fingerprint is a convention of LCM's type/marshalling layer (used by lcm-gen generated code), not a requirement of the transport framing.

## Steps to reproduce:
Decode an LCM packet where the data after the null-terminated channel name is fewer than 8 bytes (including zero bytes).

## Expected behavior:
The decoder should bounds-check the remaining data before attempting to read the fingerprint. If fewer than 8 bytes remain, it should treat the remaining data as a raw payload rather than panicking.