### PR TITLE
feat: apple pktapv1 support

### DIFF
--- a/examples/pktap/main.go
+++ b/examples/pktap/main.go
@@ -1,0 +1,247 @@
+// pktapdemo is a pure Go implementation of pktap metadata extraction,
+// equivalent to the C demo pktap_meta_demo.c.
+// It demonstrates parsing pktap v1 and v2 headers from DLT_PKTAP captures.
+//
+// Usage:
+//
+//	pktapdemo -i <interface>   live capture (macOS: uses pktap mode automatically)
+//	pktapdemo -c <count>       max packet count (default 5)
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcap"
+)
+
+const (
+	pthFlagDirIn  uint32 = 0x00000001
+	pthFlagDirOut uint32 = 0x00000002
+)
+
+// =============================================================================
+// Utility functions
+// =============================================================================
+
+func readLE16(b []byte) uint16 {
+	return uint16(b[0]) | (uint16(b[1]) << 8)
+}
+
+func readLE32(b []byte) uint32 {
+	return uint32(b[0]) | (uint32(b[1]) << 8) | (uint32(b[2]) << 16) | (uint32(b[3]) << 24)
+}
+
+func svcToString(svc uint32) string {
+	switch svc {
+	case 0:
+		return "BK_SYS"
+	case 1:
+		return "BK"
+	case 2:
+		return "BE"
+	case 3:
+		return "RD"
+	case 4:
+		return "OAM"
+	case 5:
+		return "AV"
+	case 6:
+		return "RV"
+	case 7:
+		return "VI"
+	case 8:
+		return "VO"
+	case 9:
+		return "CTL"
+	default:
+		return "UNK"
+	}
+}
+
+// =============================================================================
+// Print pktap v1 metadata (raw byte parsing, platform-independent)
+// =============================================================================
+
+func printPktapV1(data []byte, caplen int) {
+	if caplen < 156 {
+		fmt.Fprintf(os.Stderr, "  [too short for v1 header: %d < 156]\n", caplen)
+		return
+	}
+
+	hdrlen := readLE32(data[0:4])
+	fmt.Println(hdrlen)
+	if int(hdrlen) > caplen || hdrlen < 156 {
+		fmt.Fprintf(os.Stderr, "  [invalid pkt_len: %d]\n", hdrlen)
+		return
+	}
+	pth_type_next := readLE32(data[4:8])
+	fmt.Println(pth_type_next)
+
+	flags := readLE32(data[0x24:0x28])
+	innerDLT := int(readLE32(data[0x08:0x0c]))
+	pid := readLE32(data[0x34:0x38])
+	epid := readLE32(data[0x54:0x58])
+	svc := readLE32(data[0x4c:0x50])
+	iftype := readLE16(data[0x50:0x52])
+	ifunit := readLE16(data[0x52:0x54])
+
+	var ifname, cmdname, ecmdname string
+	if idx := bytes.IndexByte(data[0x0c:0x24], 0); idx >= 0 {
+		ifname = string(data[0x0c : 0x0c+idx])
+	}
+	if idx := bytes.IndexByte(data[0x38:0x4c], 0); idx >= 0 {
+		cmdname = string(data[0x38 : 0x38+idx])
+	}
+	if idx := bytes.IndexByte(data[0x58:0x6c], 0); idx >= 0 {
+		ecmdname = string(data[0x58 : 0x58+idx])
+	}
+
+	fmt.Printf("(")
+	fmt.Printf("%s %d %d", ifname, iftype, ifunit)
+	fmt.Printf(", proc %s:%d", cmdname, pid)
+	fmt.Printf(", eproc %s:%d", ecmdname, epid)
+	fmt.Printf(", svc %s", svcToString(svc))
+
+	if flags&pthFlagDirIn != 0 {
+		fmt.Printf(", in")
+	} else if flags&pthFlagDirOut != 0 {
+		fmt.Printf(", out")
+	}
+
+	if flags&^3 != 0 {
+		fmt.Printf(", flags 0x%08x", flags)
+	}
+
+	fmt.Printf(", inner_DLT %d) ", innerDLT)
+
+	innerLen := caplen - int(hdrlen)
+	fmt.Printf("[inner %d bytes]\n", innerLen)
+}
+
+// =============================================================================
+// printPacket prints decoded layers from a gopacket.Packet
+// =============================================================================
+
+func printPacket(packet gopacket.Packet) {
+	if pktapLayer := packet.Layer(layers.LayerTypePktap); pktapLayer != nil {
+		pt := pktapLayer.(*layers.PktapV1)
+		fmt.Printf("[PKTAP] Interface: %s | PID: %d | App: %s | Inner_DLT: %d\n",
+			pt.InterfaceName, pt.PID, pt.CommandName, pt.DLT)
+	}
+
+	if eth := packet.Layer(layers.LayerTypeEthernet); eth != nil {
+		layer, _ := eth.(*layers.Ethernet)
+		fmt.Printf("[Ethernet] Client MAC: %s | Server MAC: %s\n", layer.SrcMAC, layer.DstMAC)
+	}
+
+	if tplayer := packet.Layer(layers.LayerTypeTCP); tplayer != nil {
+		layer, _ := tplayer.(*layers.TCP)
+		fmt.Printf("[TCP] Client Port: %d | Server Port: %d\n", layer.SrcPort, layer.DstPort)
+	}
+
+	if iplayer := packet.Layer(layers.LayerTypeIPv4); iplayer != nil {
+		layer, _ := iplayer.(*layers.IPv4)
+		fmt.Printf("[IP] Client IP: %s | Server IP: %s\n", layer.SrcIP, layer.DstIP)
+	}
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+func main() {
+	var device string
+	var maxCount int = 5
+
+	flag.StringVar(&device, "i", "any", "interface (use 'any' or 'pktap' on macOS)")
+	flag.IntVar(&maxCount, "c", 5, "max packet count")
+	flag.Parse()
+
+	// On macOS, normalise device name to "pktap" so the kernel wraps
+	// packets with pktap v1 metadata (process info, direction, etc.).
+	deviceArg := device
+	if runtime.GOOS == "darwin" {
+		if device == "any" || device == "all" || strings.HasPrefix(device, "pktap") {
+			deviceArg = "pktap"
+		}
+	}
+
+	inactive, err := pcap.NewInactiveHandle(deviceArg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pcap.NewInactiveHandle(%s): %v\n", deviceArg, err)
+		os.Exit(1)
+	}
+	defer inactive.CleanUp()
+
+	if err := inactive.SetSnapLen(1514); err != nil {
+		fmt.Fprintf(os.Stderr, "SetSnapLen: %v\n", err)
+		os.Exit(1)
+	}
+	if err := inactive.SetPromisc(false); err != nil {
+		fmt.Fprintf(os.Stderr, "SetPromisc: %v\n", err)
+		os.Exit(1)
+	}
+	if err := inactive.SetTimeout(time.Second); err != nil {
+		fmt.Fprintf(os.Stderr, "SetTimeout: %v\n", err)
+		os.Exit(1)
+	}
+
+	// SetWantPktap requests pktap v1 metadata headers on macOS.
+	// On other platforms the method is a no-op provided by pcap_notdarwin.go.
+	if err := inactive.SetWantPktap(true); err != nil {
+		fmt.Fprintf(os.Stderr, "SetWantPktap: %v\n", err)
+		os.Exit(1)
+	}
+
+	handle, err := inactive.Activate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Activate: %v\n", err)
+		os.Exit(1)
+	}
+	defer handle.Close()
+
+	dlt := handle.LinkType()
+	fmt.Printf("DLT: %d (%s)\n", int(dlt), pcap.DatalinkValToName(int(dlt)))
+	fmt.Printf("listening on %s, link-type %s (%s), capture size %d bytes\n\n",
+		device, pcap.DatalinkValToName(int(dlt)), pcap.DatalinkValToName(int(dlt)), handle.SnapLen())
+
+	count := 0
+	for count < maxCount {
+		data, ci, err := handle.ReadPacketData()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ReadPacketData: %v\n", err)
+			break
+		}
+
+		ts := ci.Timestamp
+		fmt.Printf("%02d:%02d:%02d.%06d ", ts.Hour(), ts.Minute(), ts.Second(), ts.Nanosecond()/1000)
+
+		if dlt == layers.LinkTypeApplePKTAP {
+			printPktapV1(data, len(data))
+		} else {
+			fmt.Printf("[DLT: %s (%d), %d bytes]\n", pcap.DatalinkValToName(int(dlt)), int(dlt), len(data))
+		}
+
+		count++
+	}
+
+	fmt.Printf("\n%d packets captured\n", count)
+
+	//count := 0
+	//packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+	//for packet := range packetSource.Packets() {
+	//	printPacket(packet)
+	//	count++
+	//	if maxCount > 0 && count >= maxCount {
+	//		break
+	//	}
+	//}
+}

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -158,6 +158,7 @@ var (
 	LayerTypeModbus                       = gopacket.RegisterLayerType(153, gopacket.LayerTypeMetadata{Name: "Modbus", Decoder: gopacket.DecodeFunc(decodeModbus)})
 	LayerTypeDiameter                     = gopacket.RegisterLayerType(154, gopacket.LayerTypeMetadata{Name: "Diameter", Decoder: gopacket.DecodeFunc(decodeDiameter)})
 	LayerTypeLinuxSLL2                    = gopacket.RegisterLayerType(276, gopacket.LayerTypeMetadata{Name: "Linux SLL2", Decoder: gopacket.DecodeFunc(decodeLinuxSLL2)})
+	LayerTypePktap                        = gopacket.RegisterLayerType(300, gopacket.LayerTypeMetadata{Name: "ApplePktap", Decoder: gopacket.DecodeFunc(decodePktapV1)})
 )
 
 var (

--- a/layers/pktap.go
+++ b/layers/pktap.go
@@ -1,0 +1,187 @@
+// Copyright 2024 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gopacket/gopacket"
+)
+
+const LinkTypeApplePKTAP LinkType = 149 // Apple pktap wrapper (Darwin only)
+
+// pktap v1 record types
+const (
+	PKTRecNone   = 0
+	PKTRecPacket = 1
+)
+
+// pktap v1 direction flags (lower 2 bits of pkt_flags)
+const (
+	PTHFlagDirIn  = 0x00000001
+	PTHFlagDirOut = 0x00000002
+)
+
+// PktapDirection represents the direction of a packet
+type PktapDirection uint32
+
+func (d PktapDirection) String() string {
+	switch d {
+	case PTHFlagDirIn:
+		return "in"
+	case PTHFlagDirOut:
+		return "out"
+	}
+	return ""
+}
+
+// ServiceClass represents the SO_TC_* service class values
+type ServiceClass uint32
+
+func (s ServiceClass) String() string {
+	switch s {
+	case 0:
+		return "BK_SYS"
+	case 1:
+		return "BK"
+	case 2:
+		return "BE"
+	case 3:
+		return "RD"
+	case 4:
+		return "OAM"
+	case 5:
+		return "AV"
+	case 6:
+		return "RV"
+	case 7:
+		return "VI"
+	case 8:
+		return "VO"
+	case 9:
+		return "CTL"
+	}
+	return fmt.Sprintf("UNK(%d)", s)
+}
+
+// PktapV1 is the Darwin-specific pktap v1 metadata header.
+// It wraps packets with process/connection metadata at the kernel level.
+// see: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.81.4/bsd/net/pktap.h#L89-L114
+type PktapV1 struct {
+	BaseLayer
+	HeaderLength           uint32       // 0x00: total header length (156)
+	RecordType             uint32       // 0x04: PKT_REC_PACKET=1
+	DLT                    uint32       // 0x08: DLT type of inner packet
+	InterfaceName          string       // 0x0C: interface name (24 bytes)
+	Flags                  uint32       // 0x24: direction and other flags
+	ProtocolFamily         uint32       // 0x28: protocol family (AF_INET=2, AF_INET6=30)
+	LinkLayerHeaderLength  uint32       // 0x2C: link-layer header length
+	LinkLayerTrailerLength uint32       // 0x30: link-layer trailer length
+	PID                    uint32       // 0x34: process ID
+	CommandName            string       // 0x38: command name (20 bytes)
+	ServiceClass           ServiceClass // 0x4C: service class
+	InterfaceType          uint16       // 0x50: interface type
+	InterfaceUnit          uint16       // 0x52: unit number
+	EffectivePID           uint32       // 0x54: effective process ID
+	EffectiveCommandName   string       // 0x58: effective command name (20 bytes)
+}
+
+// LayerType returns LayerTypePktap.
+func (p *PktapV1) LayerType() gopacket.LayerType { return LayerTypePktap }
+
+// Direction returns the packet direction (in/out)
+func (p *PktapV1) Direction() PktapDirection {
+	return PktapDirection(p.Flags & 0x3)
+}
+
+// CanDecode returns the set of layer types that this DecodingLayer can decode.
+func (p *PktapV1) CanDecode() gopacket.LayerClass {
+	return LayerTypePktap
+}
+
+// NextLayerType returns the layer type of the inner packet (determined by DLT)
+func (p *PktapV1) NextLayerType() gopacket.LayerType {
+	return LinkType(p.DLT).LayerType()
+}
+
+// DecodeFromBytes decodes the given bytes into this layer.
+func (p *PktapV1) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	//sizeof(struct pktap_header) == 156
+	if len(data) < 156 {
+		return errors.New("pktap packet too small")
+	}
+
+	p.HeaderLength = binary.LittleEndian.Uint32(data[0:4])
+	if p.HeaderLength < 156 {
+		return fmt.Errorf("pktap v1 header length mismatch: got %d", p.HeaderLength)
+	}
+
+	p.RecordType = binary.LittleEndian.Uint32(data[4:8])
+	if p.RecordType != PKTRecPacket {
+		return fmt.Errorf("pktap unsupported record type: %d", p.RecordType)
+	}
+
+	p.DLT = binary.LittleEndian.Uint32(data[8:12])
+
+	// Interface name: 24 bytes at offset 0x0C, null-terminated
+	ifname := string(data[0x0C : 0x0C+24])
+	if nullIdx := strings.Index(ifname, "\x00"); nullIdx >= 0 {
+		ifname = ifname[:nullIdx]
+	}
+	p.InterfaceName = ifname
+
+	p.Flags = binary.LittleEndian.Uint32(data[0x24:0x28])
+	p.ProtocolFamily = binary.LittleEndian.Uint32(data[0x28:0x2C])
+	p.LinkLayerHeaderLength = binary.LittleEndian.Uint32(data[0x2C:0x30])
+	p.LinkLayerTrailerLength = binary.LittleEndian.Uint32(data[0x30:0x34])
+	p.PID = binary.LittleEndian.Uint32(data[0x34:0x38])
+
+	// Command name: 20 bytes at offset 0x38, null-terminated
+	cmdname := string(data[0x38 : 0x38+20])
+	if nullIdx := strings.Index(cmdname, "\x00"); nullIdx >= 0 {
+		cmdname = cmdname[:nullIdx]
+	}
+	p.CommandName = cmdname
+
+	p.ServiceClass = ServiceClass(binary.LittleEndian.Uint32(data[0x4C:0x50]))
+	p.InterfaceType = binary.LittleEndian.Uint16(data[0x50:0x52])
+	p.InterfaceUnit = binary.LittleEndian.Uint16(data[0x52:0x54])
+	p.EffectivePID = binary.LittleEndian.Uint32(data[0x54:0x58])
+
+	// Effective command name: 20 bytes at offset 0x58, null-terminated
+	ecmdname := string(data[0x58 : 0x58+20])
+	if nullIdx := strings.Index(ecmdname, "\x00"); nullIdx >= 0 {
+		ecmdname = ecmdname[:nullIdx]
+	}
+	p.EffectiveCommandName = ecmdname
+
+	p.BaseLayer = BaseLayer{Contents: data[:p.HeaderLength], Payload: data[p.HeaderLength:]}
+	return nil
+}
+
+// String returns a human-readable representation of the pktap metadata.
+func (p *PktapV1) String() string {
+	return fmt.Sprintf("PktapV1(%s, proc %s:%d, eproc %s:%d, svc %s, %s, DLT %s (%d))",
+		p.InterfaceName,
+		p.CommandName, p.PID,
+		p.EffectiveCommandName, p.EffectivePID,
+		p.ServiceClass,
+		p.Direction(),
+		LinkType(p.DLT), p.DLT)
+}
+
+func decodePktapV1(data []byte, p gopacket.PacketBuilder) error {
+	pktap := &PktapV1{}
+	if err := pktap.DecodeFromBytes(data, p); err != nil {
+		return err
+	}
+	p.AddLayer(pktap)
+	return p.NextDecoder(LinkType(pktap.DLT))
+}

--- a/layers/pktap_darwin.go
+++ b/layers/pktap_darwin.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+//go:build darwin
+// +build darwin
+
+package layers
+
+import (
+	"github.com/gopacket/gopacket"
+)
+
+/*
+#define DLT_USER2		149
+
+#ifdef __APPLE__
+#define DLT_PKTAP	DLT_USER2
+#else
+#define DLT_PKTAP	258
+#endif
+*/
+
+func init() {
+	LinkTypeMetadata[LinkTypeApplePKTAP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodePktapV1), Name: "ApplePKTAP"}
+}

--- a/layers/pktap_test.go
+++ b/layers/pktap_test.go
@@ -1,0 +1,136 @@
+package layers
+
+import (
+	"encoding/hex"
+	"net"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+)
+
+func TestPktapV1_ethernet(t *testing.T) {
+	// en10 Google Chrome He:2227 -> 123.117.132.38:443 SYN-ACK (in)
+	// Flags=0x00021001 DLT=1(Ethernet) inner=74 bytes
+	var raw = "9c0000000100000001000000656e3130000000000000000000000000000000000000000001100200020000000e00000000000000b3080000476f6f676c65204368726f6d65204865000600000000000006000a00b3080000476f6f676c65204368726f6d6520486500000000083d0dbe0000000000000000000000004c4c443655553144a1189540bad5b0580000000000000000000000000000000004d9c809f0168465692d4a8f08004500003c0000400032068ced7b758426ac12102101bbd3d640f76ce1fb022591a012ffff1d0e0000020405840402080a317f0b7c1d22712501030309"
+	pr, err := hex.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("hex decode: %v", err)
+	}
+
+	p := gopacket.NewPacket(pr, LayerTypePktap, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Fatalf("decode error: %v", p.ErrorLayer().Error())
+	}
+
+	// --- pktap header ---
+	pktapLayer := p.Layer(LayerTypePktap)
+	if pktapLayer == nil {
+		t.Fatal("LayerTypePktap not found")
+	}
+	pt := pktapLayer.(*PktapV1)
+
+	if pt.InterfaceName != "en10" {
+		t.Errorf("InterfaceName: got %q, want %q", pt.InterfaceName, "en10")
+	}
+	if pt.DLT != 1 {
+		t.Errorf("DLT: got %d, want 1 (Ethernet)", pt.DLT)
+	}
+	if pt.PID != 2227 {
+		t.Errorf("PID: got %d, want 2227", pt.PID)
+	}
+	if pt.CommandName != "Google Chrome He" {
+		t.Errorf("CommandName: got %q, want %q", pt.CommandName, "Google Chrome He")
+	}
+	if pt.EffectivePID != 2227 {
+		t.Errorf("EffectivePID: got %d, want 2227", pt.EffectivePID)
+	}
+	if pt.EffectiveCommandName != "Google Chrome He" {
+		t.Errorf("EffectiveCommandName: got %q, want %q", pt.EffectiveCommandName, "Google Chrome He")
+	}
+	if pt.Flags != 0x00021001 {
+		t.Errorf("Flags: got 0x%08x, want 0x00021001", pt.Flags)
+	}
+	if pt.Direction() != PTHFlagDirIn {
+		t.Errorf("Direction: got %v, want in", pt.Direction())
+	}
+
+	// --- Ethernet ---
+	ethLayer := p.Layer(LayerTypeEthernet)
+	if ethLayer == nil {
+		t.Fatal("LayerTypeEthernet not found")
+	}
+	eth := ethLayer.(*Ethernet)
+	if eth.EthernetType != EthernetTypeIPv4 {
+		t.Errorf("EthernetType: got %v, want IPv4", eth.EthernetType)
+	}
+
+	// --- IPv4 ---
+	ipLayer := p.Layer(LayerTypeIPv4)
+	if ipLayer == nil {
+		t.Fatal("LayerTypeIPv4 not found")
+	}
+	ip := ipLayer.(*IPv4)
+	if !ip.SrcIP.Equal(net.ParseIP("123.117.132.38")) {
+		t.Errorf("SrcIP: got %s, want 123.117.132.38", ip.SrcIP)
+	}
+	if !ip.DstIP.Equal(net.ParseIP("172.18.16.33")) {
+		t.Errorf("DstIP: got %s, want 172.18.16.33", ip.DstIP)
+	}
+
+	// --- TCP ---
+	tcpLayer := p.Layer(LayerTypeTCP)
+	if tcpLayer == nil {
+		t.Fatal("LayerTypeTCP not found")
+	}
+	tcp := tcpLayer.(*TCP)
+	if tcp.SrcPort != 443 {
+		t.Errorf("SrcPort: got %d, want 443", tcp.SrcPort)
+	}
+	if tcp.DstPort != 54230 {
+		t.Errorf("DstPort: got %d, want 54230", tcp.DstPort)
+	}
+	if !tcp.SYN || !tcp.ACK {
+		t.Errorf("TCP flags: got SYN=%v ACK=%v, want SYN=true ACK=true", tcp.SYN, tcp.ACK)
+	}
+}
+
+func TestPktapV1_utun(t *testing.T) {
+	//utun4 Spotify Helper:794
+	//11.11.11.11:5228->15.251.130.147:64356
+	var testPktapPacketHex = "9c00000001000000000000007574756e3400000000000000000000000000000000000000010002000200000004000000000000001a03000053706f746966792048656c7065720000000000000000000001000400ffffffff000000000000000000000000000000000000000000000000000000000000000000000000d73db7bdb5cc3293a7642307c8beb82f00000000000000000000000000000000020000004500003ca5ac0000400633e50b0b0b0b0ffb8293146cfb6452a1b86d4e2060d0a012720001690000020405b40402080adb52d790a46a123f01030305"
+	pr, err := hex.DecodeString(testPktapPacketHex)
+	if err != nil {
+		t.Errorf("Error decoding hex packet: %v", err)
+	}
+
+	p := gopacket.NewPacket(pr, LayerTypePktap, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Errorf("LayerTypePktap: %v", p.ErrorLayer().Error())
+	}
+	pktapLayer := p.Layer(LayerTypePktap)
+	if pktapLayer == nil {
+		t.Errorf("LayerTypePktap layer not found")
+	}
+	pt := pktapLayer.(*PktapV1)
+	if pt.InterfaceName != "utun4" {
+		t.Errorf("InterfaceName mismatch: got %s", pt.InterfaceName)
+	}
+
+	tplayer := p.Layer(LayerTypeTCP)
+	if tplayer == nil {
+		t.Errorf("LayerTypeTCP layer not found")
+	}
+	tlayer := tplayer.(*TCP)
+	if tlayer.SrcPort != 5228 || tlayer.DstPort != 64356 {
+		t.Errorf("TCP port mismatch: got %d, %d", tlayer.SrcPort, tlayer.DstPort)
+	}
+
+	iplayer := p.Layer(LayerTypeIPv4)
+	if iplayer == nil {
+		t.Errorf("LayerTypeIPv4 layer not found")
+	}
+	ilayer := iplayer.(*IPv4)
+	if ilayer.SrcIP.String() != "11.11.11.11" {
+		t.Errorf("SrcIP mismatch: got %s", ilayer.SrcIP.String())
+	}
+}

--- a/pcap/pcap_darwin.go
+++ b/pcap/pcap_darwin.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+//go:build darwin
+// +build darwin
+
+package pcap
+
+/*
+#cgo darwin LDFLAGS: -lpcap
+
+#include <pcap.h>
+
+extern int pcap_set_want_pktap(pcap_t *, int);
+*/
+import "C"
+
+const (
+	DLT_PKTAP = C.DLT_PKTAP
+)
+
+// SetWantPktap calls pcap_set_want_pktap on the pcap handle.
+// This is a Darwin-specific function that tells the kernel to wrap packets
+// with pktap metadata when capturing. This must be called before Activate.
+// see: https://github.com/apple-oss-distributions/tcpdump/blob/tcpdump-156/tcpdump/tcpdump.c#L1541
+// see: https://github.com/apple-oss-distributions/libpcap/blob/libpcap-144/libpcap/pcap/pcap.h#L1240-L1244
+func (p *InactiveHandle) SetWantPktap(wantPktap bool) error {
+	var v C.int
+	if wantPktap {
+		v = 1
+	}
+
+	if status := C.pcap_set_want_pktap(p.cptr, v); status < 0 {
+		return statusError(status)
+	}
+	return nil
+}

--- a/pcap/pcap_notdarwin.go
+++ b/pcap/pcap_notdarwin.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+//go:build !darwin
+// +build !darwin
+
+package pcap
+
+// SetWantPktap is a no-op on non-Darwin platforms.
+// pktap metadata headers are a macOS kernel feature only.
+func (p *InactiveHandle) SetWantPktap(_ bool) error {
+	return nil
+}


### PR DESCRIPTION
capture Darwin-specific packets with pktap metadata.
// see: https://github.com/apple-oss-distributions/tcpdump/blob/tcpdump-156/tcpdump/tcpdump.c#L1541
// see: https://github.com/apple-oss-distributions/libpcap/blob/libpcap-144/libpcap/pcap/pcap.h#L1240-L1244