### PR TITLE
gre: add bounds checking

### DIFF
--- a/layers/gre.go
+++ b/layers/gre.go
@@ -8,6 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 
 	"github.com/gopacket/gopacket"
 )
@@ -37,6 +38,28 @@ func (g *GRE) LayerType() gopacket.LayerType { return LayerTypeGRE }
 
 // DecodeFromBytes decodes the given bytes into this layer.
 func (g *GRE) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 4 {
+		df.SetTruncated()
+		return errors.New("GRE packet too small")
+	}
+	truncated := func() error {
+		df.SetTruncated()
+		return errors.New("GRE packet truncated")
+	}
+	requireBytes := func(offset, size int) error {
+		if len(data)-offset < size {
+			return truncated()
+		}
+		return nil
+	}
+
+	g.BaseLayer = BaseLayer{}
+	g.GRERouting = nil
+	g.Checksum = 0
+	g.Offset = 0
+	g.Key = 0
+	g.Seq = 0
+	g.Ack = 0
 	g.ChecksumPresent = data[0]&0x80 != 0
 	g.RoutingPresent = data[0]&0x40 != 0
 	g.KeyPresent = data[0]&0x20 != 0
@@ -49,25 +72,40 @@ func (g *GRE) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	g.Protocol = EthernetType(binary.BigEndian.Uint16(data[2:4]))
 	offset := 4
 	if g.ChecksumPresent || g.RoutingPresent {
+		if err := requireBytes(offset, 4); err != nil {
+			return err
+		}
 		g.Checksum = binary.BigEndian.Uint16(data[offset : offset+2])
 		g.Offset = binary.BigEndian.Uint16(data[offset+2 : offset+4])
 		offset += 4
 	}
 	if g.KeyPresent {
+		if err := requireBytes(offset, 4); err != nil {
+			return err
+		}
 		g.Key = binary.BigEndian.Uint32(data[offset : offset+4])
 		offset += 4
 	}
 	if g.SeqPresent {
+		if err := requireBytes(offset, 4); err != nil {
+			return err
+		}
 		g.Seq = binary.BigEndian.Uint32(data[offset : offset+4])
 		offset += 4
 	}
 	if g.RoutingPresent {
 		tail := &g.GRERouting
 		for {
+			if err := requireBytes(offset, 4); err != nil {
+				return err
+			}
 			sre := &GRERouting{
 				AddressFamily: binary.BigEndian.Uint16(data[offset : offset+2]),
 				SREOffset:     data[offset+2],
 				SRELength:     data[offset+3],
+			}
+			if err := requireBytes(offset+4, int(sre.SRELength)); err != nil {
+				return err
 			}
 			sre.RoutingInformation = data[offset+4 : offset+4+int(sre.SRELength)]
 			offset += 4 + int(sre.SRELength)
@@ -79,6 +117,9 @@ func (g *GRE) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		}
 	}
 	if g.AckPresent {
+		if err := requireBytes(offset, 4); err != nil {
+			return err
+		}
 		g.Ack = binary.BigEndian.Uint32(data[offset : offset+4])
 		offset += 4
 	}

--- a/layers/gre_test.go
+++ b/layers/gre_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/gopacket/gopacket"
 )
 
+type truncationDecodeFeedback struct {
+	truncated bool
+}
+
+func (t *truncationDecodeFeedback) SetTruncated() {
+	t.truncated = true
+}
+
 // testPacketGRE is the packet:
 //
 //	15:08:08.003196 IP 192.168.1.1 > 192.168.1.2: GREv0, length 88: IP 172.16.1.1 > 172.16.2.1: ICMP echo request, id 4724, seq 1, length 64
@@ -254,6 +262,43 @@ func BenchmarkEncodePacketEthernetOverGRE(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		gopacket.SerializeLayers(buf, opts, testEthernetOverGRE...)
 		buf.Clear()
+	}
+}
+
+func TestGREDecodeFromBytesTruncatedOptionalFields(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "missing checksum and offset",
+			data: []byte{0x80, 0x00, 0x08, 0x00},
+		},
+		{
+			name: "missing ack field",
+			data: []byte{0x00, 0x80, 0x08, 0x00},
+		},
+		{
+			name: "routing sre length overruns packet",
+			data: []byte{
+				0x40, 0x00, 0x08, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x01, 0x00, 0x10,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gre GRE
+			df := &truncationDecodeFeedback{}
+			if err := gre.DecodeFromBytes(tt.data, df); err == nil {
+				t.Fatal("expected decode error")
+			}
+			if !df.truncated {
+				t.Fatal("expected packet to be marked truncated")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Added bounds checks to `layers/gre.go` to prevent panics. Here's an example I ran into:

```
runtime error: slice bounds out of range [:308] with capacity 122
         file: github.com/gopacket/gopacket@v1.5.0/layers/gre.go:72 +0x411
         func: layers.(*GRE).DecodeFromBytes(0xc000954360, {0xc000626766, 0x78, 0x7a}, {0x11e1840?, 0xc000830101?})
```